### PR TITLE
BooruOptions enumeration improvements

### DIFF
--- a/BooruSharp/Booru/ABooru.cs
+++ b/BooruSharp/Booru/ABooru.cs
@@ -96,12 +96,17 @@ namespace BooruSharp.Booru
             await HttpClient.SendAsync(new HttpRequestMessage(HttpMethod.Head, _imageUrl));
         }
 
+        [Obsolete(_deprecationMessage)]
         protected ABooru(string baseUrl, UrlFormat format, params BooruOptions[] options)
+            : this(baseUrl, format, MergeOptions(options))
+        { }
+
+        protected ABooru(string baseUrl, UrlFormat format, BooruOptions options)
         {
             Auth = null;
             HttpClient = null;
-            _useHttp = options.Contains(BooruOptions.useHttp);
-            _maxLimit = options.Contains(BooruOptions.limitOf20000);
+            _useHttp = options.HasFlag(BooruOptions.useHttp);
+            _maxLimit = options.HasFlag(BooruOptions.limitOf20000);
             _baseUrl = "http" + (_useHttp ? "" : "s") + "://" + baseUrl;
             _format = format;
             _imageUrl = "http" + (_useHttp ? "" : "s") + "://" + baseUrl + "/" + GetUrl(format, "post");
@@ -111,30 +116,30 @@ namespace BooruSharp.Booru
                 _imageUrlXml = _imageUrl.Replace("index.json", "index.xml");
             else
                 _imageUrlXml = null;
-            _searchTagById = !options.Contains(BooruOptions.noTagById);
-            _searchLastComment = !options.Contains(BooruOptions.noLastComments);
-            _searchPostByMd5 = !options.Contains(BooruOptions.noPostByMd5);
-            _searchPostById = !options.Contains(BooruOptions.noPostById);
-            _postCount = !options.Contains(BooruOptions.noPostCount);
-            _multipleRandom = !options.Contains(BooruOptions.noMultipleRandom);
-            _addFavorite = !options.Contains(BooruOptions.noFavorite);
-            _tagUseXml = options.Contains(BooruOptions.tagApiXml);
-            _commentUseXml = options.Contains(BooruOptions.commentApiXml);
-            _noMoreThan2Tags = options.Contains(BooruOptions.noMoreThan2Tags);
+            _searchTagById = !options.HasFlag(BooruOptions.noTagById);
+            _searchLastComment = !options.HasFlag(BooruOptions.noLastComments);
+            _searchPostByMd5 = !options.HasFlag(BooruOptions.noPostByMd5);
+            _searchPostById = !options.HasFlag(BooruOptions.noPostById);
+            _postCount = !options.HasFlag(BooruOptions.noPostCount);
+            _multipleRandom = !options.HasFlag(BooruOptions.noMultipleRandom);
+            _addFavorite = !options.HasFlag(BooruOptions.noFavorite);
+            _tagUseXml = options.HasFlag(BooruOptions.tagApiXml);
+            _commentUseXml = options.HasFlag(BooruOptions.commentApiXml);
+            _noMoreThan2Tags = options.HasFlag(BooruOptions.noMoreThan2Tags);
             _tagUrl = "http" + (_useHttp ? "" : "s") + "://" + baseUrl + "/" + GetUrl(format, "tag");
-            if (options.Contains(BooruOptions.noWiki))
+            if (options.HasFlag(BooruOptions.noWiki))
                 _wikiUrl = null;
             else if (format == UrlFormat.danbooru)
                 _wikiUrl = "http" + (_useHttp ? "" : "s") + "://" + baseUrl + "/" + GetUrl(format, "wiki_page");
             else
                 _wikiUrl = "http" + (_useHttp ? "" : "s") + "://" + baseUrl + "/" + GetUrl(format, "wiki");
-            if (options.Contains(BooruOptions.noRelated))
+            if (options.HasFlag(BooruOptions.noRelated))
                 _relatedUrl = null;
             else if (format == UrlFormat.danbooru)
                 _relatedUrl = "http" + (_useHttp ? "" : "s") + "://" + baseUrl + "/" + GetUrl(format, "related_tag");
             else
                 _relatedUrl = "http" + (_useHttp ? "" : "s") + "://" + baseUrl + "/" + GetUrl(format, "tag", "related");
-            if (options.Contains(BooruOptions.noComment))
+            if (options.HasFlag(BooruOptions.noComment))
             {
                 _commentUrl = null;
                 _searchLastComment = false;
@@ -215,12 +220,32 @@ namespace BooruSharp.Booru
                 return value + "=";
         }
 
+        [Obsolete]
+        // TODO: remove this method after removing obsolete constructors.
         protected internal static BooruOptions[] CombineArrays(BooruOptions[] arr1, BooruOptions[] arr2)
         {
             var arr = new BooruOptions[arr1.Length + arr2.Length];
             arr1.CopyTo(arr, 0);
             arr2.CopyTo(arr, arr1.Length);
             return arr;
+        }
+
+        /// <summary>
+        /// Method for compatibility with old API. Combines multiple options
+        /// into singular <see cref="BooruOptions"/> object.
+        /// </summary>
+        // TODO: remove this method after removing obsolete constructors.
+        [Obsolete("This method will be removed in the future version of the API.")]
+        protected static BooruOptions MergeOptions(BooruOptions[] array)
+        {
+            BooruOptions options = BooruOptions.none;
+
+            for (int i = 0; i < array.Length; i++)
+            {
+                options |= array[i];
+            }
+
+            return options;
         }
 
         public BooruAuth Auth { set; get; } // Authentification
@@ -241,5 +266,7 @@ namespace BooruSharp.Booru
         private readonly UrlFormat _format; // URL format
         protected readonly bool _useHttp; // Use http instead of https
         protected static readonly Random _random = new Random();
+        // TODO: remove this message after removing obsolete constructors.
+        protected const string _deprecationMessage = "Use a contructor that accepts single BooruOptions parameter. Use | (bitwise OR) operator to combine multiple options.";
     }
 }

--- a/BooruSharp/Booru/BooruOptions.cs
+++ b/BooruSharp/Booru/BooruOptions.cs
@@ -1,23 +1,27 @@
-﻿namespace BooruSharp.Booru
+﻿using System;
+
+namespace BooruSharp.Booru
 {
+    [Flags]
     public enum BooruOptions
     {
-        useHttp, // http instead of https
+        none = 0,
+        useHttp = 1 << 0, // http instead of https
         // Missing API
-        noWiki,
-        noRelated,
-        noComment,
-        noTagById,
-        noPostByMd5,
-        noPostById,
-        noLastComments,
-        noPostCount,
-        noMultipleRandom,
-        noFavorite,
+        noWiki = 1 << 1,
+        noRelated = 1 << 2,
+        noComment = 1 << 3,
+        noTagById = 1 << 4,
+        noPostByMd5 = 1 << 5,
+        noPostById = 1 << 6,
+        noLastComments = 1 << 7,
+        noPostCount = 1 << 8,
+        noMultipleRandom = 1 << 9,
+        noFavorite = 1 << 10,
         // API using XML instead of JSON
-        commentApiXml,
-        tagApiXml,
-        limitOf20000, // Limit of 20000 posts per search, used for Gelbooru
-        noMoreThan2Tags
+        commentApiXml = 1 << 11,
+        tagApiXml = 1 << 12,
+        limitOf20000 = 1 << 13, // Limit of 20000 posts per search, used for Gelbooru
+        noMoreThan2Tags = 1 << 14,
     }
 }

--- a/BooruSharp/Booru/Template/Danbooru.cs
+++ b/BooruSharp/Booru/Template/Danbooru.cs
@@ -6,7 +6,11 @@ namespace BooruSharp.Booru.Template
 {
     public abstract class Danbooru : ABooru
     {
-        public Danbooru(string url, params BooruOptions[] options) : base(url, UrlFormat.danbooru, CombineArrays(options, new[] { BooruOptions.noLastComments, BooruOptions.noPostCount, BooruOptions.noFavorite }))
+        [Obsolete(_deprecationMessage)]
+        public Danbooru(string url, params BooruOptions[] options) : this(url, MergeOptions(options))
+        { }
+
+        public Danbooru(string url, BooruOptions options = BooruOptions.none) : base(url, UrlFormat.danbooru, options | BooruOptions.noLastComments | BooruOptions.noPostCount | BooruOptions.noFavorite)
         { }
 
         protected internal override JToken ParseFirstPostSearchResult(object json)

--- a/BooruSharp/Booru/Template/E621.cs
+++ b/BooruSharp/Booru/Template/E621.cs
@@ -7,7 +7,11 @@ namespace BooruSharp.Booru.Template
 {
     public abstract class E621 : ABooru
     {
-        public E621(string url, params BooruOptions[] options) : base(url, UrlFormat.danbooru, CombineArrays(options, new[] { BooruOptions.noWiki, BooruOptions.noRelated, BooruOptions.noComment, BooruOptions.noTagById, BooruOptions.noPostById, BooruOptions.noPostCount, BooruOptions.noFavorite }))
+        [Obsolete(_deprecationMessage)]
+        public E621(string url, params BooruOptions[] options) : this(url, MergeOptions(options))
+        { }
+
+        public E621(string url, BooruOptions options = BooruOptions.none) : base(url, UrlFormat.danbooru, options | BooruOptions.noWiki | BooruOptions.noRelated | BooruOptions.noComment | BooruOptions.noTagById | BooruOptions.noPostById | BooruOptions.noPostCount | BooruOptions.noFavorite)
         { }
 
         protected internal override JToken ParseFirstPostSearchResult(object json)

--- a/BooruSharp/Booru/Template/Gelbooru.cs
+++ b/BooruSharp/Booru/Template/Gelbooru.cs
@@ -15,8 +15,12 @@ namespace BooruSharp.Booru.Template
     /// </summary>
     public abstract class Gelbooru : ABooru
     {
-        public Gelbooru(string url, params BooruOptions[] options) : base(url, UrlFormat.indexPhp, CombineArrays(options,
-            new[] { BooruOptions.noWiki, BooruOptions.noRelated, BooruOptions.limitOf20000, BooruOptions.commentApiXml }))
+        [Obsolete(_deprecationMessage)]
+        public Gelbooru(string url, params BooruOptions[] options) : this(url, MergeOptions(options))
+        { }
+
+        public Gelbooru(string url, BooruOptions options = BooruOptions.none) : base(url, UrlFormat.indexPhp, options |
+             BooruOptions.noWiki | BooruOptions.noRelated | BooruOptions.limitOf20000 | BooruOptions.commentApiXml)
         { }
 
         public async override Task<Search.Post.SearchResult> GetPostByMd5Async(string md5)

--- a/BooruSharp/Booru/Template/Gelbooru02.cs
+++ b/BooruSharp/Booru/Template/Gelbooru02.cs
@@ -11,8 +11,12 @@ namespace BooruSharp.Booru.Template
     /// </summary>
     public abstract class Gelbooru02 : ABooru
     {
-        public Gelbooru02(string url, params BooruOptions[] options) : base(url, UrlFormat.indexPhp, CombineArrays(options,
-            new[] { BooruOptions.noRelated, BooruOptions.noWiki, BooruOptions.noPostByMd5, BooruOptions.commentApiXml, BooruOptions.tagApiXml, BooruOptions.noMultipleRandom }))
+        [Obsolete(_deprecationMessage)]
+        public Gelbooru02(string url, params BooruOptions[] options) : this(url, MergeOptions(options))
+        { }
+
+        public Gelbooru02(string url, BooruOptions options = BooruOptions.none) : base(url, UrlFormat.indexPhp, options |
+             BooruOptions.noRelated | BooruOptions.noWiki | BooruOptions.noPostByMd5 | BooruOptions.commentApiXml | BooruOptions.tagApiXml | BooruOptions.noMultipleRandom)
         {
             this.url = url;
         }

--- a/BooruSharp/Booru/Template/Moebooru.cs
+++ b/BooruSharp/Booru/Template/Moebooru.cs
@@ -6,7 +6,11 @@ namespace BooruSharp.Booru.Template
 {
     public abstract class Moebooru : ABooru
     {
-        public Moebooru(string url, params BooruOptions[] options) : base(url, UrlFormat.postIndexJson, CombineArrays(options, new[] { BooruOptions.noPostByMd5, BooruOptions.noPostById, BooruOptions.noFavorite }))
+        [Obsolete(_deprecationMessage)]
+        public Moebooru(string url, params BooruOptions[] options) : this(url, MergeOptions(options))
+        { }
+
+        public Moebooru(string url, BooruOptions options = BooruOptions.none) : base(url, UrlFormat.postIndexJson, options | BooruOptions.noPostByMd5 | BooruOptions.noPostById | BooruOptions.noFavorite)
         { }
 
         protected internal override JToken ParseFirstPostSearchResult(object json)

--- a/BooruSharp/Booru/Template/Sankaku.cs
+++ b/BooruSharp/Booru/Template/Sankaku.cs
@@ -7,7 +7,11 @@ namespace BooruSharp.Booru.Template
 {
     public abstract class Sankaku : ABooru
     {
-        public Sankaku(string url, params BooruOptions[] options) : base(url, UrlFormat.sankaku, CombineArrays(options, new[] { BooruOptions.noRelated, BooruOptions.noPostByMd5, BooruOptions.noPostById, BooruOptions.noPostCount, BooruOptions.noFavorite }))
+        [Obsolete(_deprecationMessage)]
+        public Sankaku(string url, params BooruOptions[] options) : this(url, MergeOptions(options))
+        { }
+
+        public Sankaku(string url, BooruOptions options = BooruOptions.none) : base(url, UrlFormat.sankaku, options | BooruOptions.noRelated | BooruOptions.noPostByMd5 | BooruOptions.noPostById | BooruOptions.noPostCount | BooruOptions.noFavorite)
         { }
 
         protected internal override JToken ParseFirstPostSearchResult(object json)


### PR DESCRIPTION
This PR changes the way how `BooruOptions` enumeration works.

`BooruOptions` enum marked with `FlagsAttribute` lets us check for flags that are set on the enum object with `HasFlag(BooruOptions)` instance method, and enables prettier string representation of the enum object. Creating `BooruOptions` object with multiple flags is a matter of bitwise ORing multiple enum values, like this:
```csharp
BooruOptions options = BooruOptions.noWiki | BooruOptions.noFavorite;
bool noWiki = options.HasFlag(BooruOptions.noWiki);       // true
bool noComment = options.HasFlag(BooruOptions.noComment); // false
string str = options.ToString(); // "noWiki, noFavorite"
```
It means we can pass a single `BooruOptions` object to `ABooru()` constructor and look for the flags using that singular object instead of passing `BooruOptions[]` array and enumerating it every time we want to look for an option. This also imposes a limit of 32 flags (since `BooruOptions` is backed by `int` that has 32 bit positions), or 64 flags if `long` is used for backing `BooruOptions`.

Booru constructors that accept `params BooruOptions[] options` are now marked with `ObsoleteAttribute` (as they are superseded by simpler `BooruOptions options` variant). I added static `ABooru.MergeOptions(BooruOptions[] array)` helper method for easier transition to new `BooruOptions` semantics. Until members marked with `ObsoleteAttribute` are removed later with the next major version release, these changes keep BooruSharp fully backwards compatible with the previous version.