### PR TITLE
ABooru HttpClient improvements

### DIFF
--- a/BooruSharp/Booru/ABooru.cs
+++ b/BooruSharp/Booru/ABooru.cs
@@ -257,8 +257,12 @@ namespace BooruSharp.Booru
             set
             {
                 _client = value;
-                // Add our User-Agent if _client isn't null.
-                _client?.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 BooruSharp");
+
+                // Add our User-Agent if client's User-Agent header is empty.
+                if (_client != null && !_client.DefaultRequestHeaders.Contains("User-Agent"))
+                {
+                    _client.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 BooruSharp");
+                }
             }
         }
 


### PR DESCRIPTION
As per [Microsoft Docs](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient?view=netstandard-2.0#remarks), `HttpClient` is intended to be instantiated once and re-used throughout the life of an application. This PR adds a `HttpClient` singleton in `ABooru` class that can be referenced using protected getter.
Library consumers are still allowed to provide their own `HttpClient` instance, and if not `null`, it will be used over the `HttpClient` singleton.

Also (as per [Microsoft Docs](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.defaultrequestheaders?view=netstandard-2.0#remarks)) User-Agent header doesn't need to be set every time we're sending a request, so the `HttpClient` singleton will be initialized with User-Agent header added. Let library consumers figure out what User-Agent they want to have when they provide their own `HttpClient` instance.