### PR TITLE
ABooru cleanup

### DIFF
--- a/BooruSharp/Booru/Template/Gelbooru02.cs
+++ b/BooruSharp/Booru/Template/Gelbooru02.cs
@@ -32,8 +32,8 @@ namespace BooruSharp.Booru.Template
         protected internal override Search.Post.SearchResult GetPostSearchResult(JToken elem)
         {
             return new Search.Post.SearchResult(
-                    new Uri("http" + (_useHttp ? "" : "s") + "://" + url + "//images/" + elem["directory"].Value<string>() + "/" + elem["image"].Value<string>()),
-                    new Uri("http" + (_useHttp ? "" : "s") + "://" + url + "//thumbnails/" + elem["directory"].Value<string>() + "/thumbnails_" + elem["image"].Value<string>()),
+                    new Uri("http" + (UsesHttp() ? "" : "s") + "://" + url + "//images/" + elem["directory"].Value<string>() + "/" + elem["image"].Value<string>()),
+                    new Uri("http" + (UsesHttp() ? "" : "s") + "://" + url + "//thumbnails/" + elem["directory"].Value<string>() + "/thumbnails_" + elem["image"].Value<string>()),
                     new Uri(_baseUrl + "/index.php?page=post&s=view&id=" + elem["id"].Value<int>()),
                     GetRating(elem["rating"].Value<string>()[0]),
                     elem["tags"].Value<string>().Split(' '),

--- a/BooruSharp/Search/Comment/ABooru.cs
+++ b/BooruSharp/Search/Comment/ABooru.cs
@@ -13,11 +13,11 @@ namespace BooruSharp.Booru
         /// <param name="postId">The ID of the post to get information about</param>
         public virtual async Task<Search.Comment.SearchResult[]> GetCommentsAsync(int postId)
         {
-            if (_commentUrl == null)
+            if (!HasCommentAPI())
                 throw new Search.FeatureUnavailable();
             string url = CreateUrl(_commentUrl, SearchArg("post_id") + postId);
             List<Search.Comment.SearchResult> results = new List<Search.Comment.SearchResult>();
-            if (_commentUseXml)
+            if (CommentsUseXml())
             {
                 var xml = await GetXmlAsync(url);
                 foreach (var node in xml.LastChild)
@@ -45,11 +45,11 @@ namespace BooruSharp.Booru
         /// </summary>
         public virtual async Task<Search.Comment.SearchResult[]> GetLastCommentsAsync()
         {
-            if (_commentUrl == null || !_searchLastComment)
+            if (!HasSearchLastComment())
                 throw new Search.FeatureUnavailable();
             string url = CreateUrl(_commentUrl);
             Search.Comment.SearchResult[] results;
-            if (_commentUseXml)
+            if (CommentsUseXml())
             {
                 var xml = await GetXmlAsync(url);
                 results = new Search.Comment.SearchResult[xml.LastChild.ChildNodes.Count];

--- a/BooruSharp/Search/Post/ABooru.cs
+++ b/BooruSharp/Search/Post/ABooru.cs
@@ -45,7 +45,7 @@ namespace BooruSharp.Booru
                 throw new Search.FeatureUnavailable();
             if (tagsArg == null) tagsArg = new string[0];
             else tagsArg = tagsArg.Where(x => !string.IsNullOrWhiteSpace(x)).ToArray();
-            if (tagsArg.Length > 2 && _noMoreThan2Tags)
+            if (tagsArg.Length > 2 && NoMoreThanTwoTags())
                 throw new Search.TooManyTags();
             XmlDocument xml = await GetXmlAsync(CreateUrl(_imageUrlXml, "limit=1", TagsToString(tagsArg)));
             return int.Parse(xml.ChildNodes.Item(1).Attributes[0].InnerXml);
@@ -59,7 +59,7 @@ namespace BooruSharp.Booru
         {
             if (tagsArg == null) tagsArg = new string[0];
             else tagsArg = tagsArg.Where(x => !string.IsNullOrWhiteSpace(x)).ToArray();
-            if (tagsArg.Length > 2 && _noMoreThan2Tags)
+            if (tagsArg.Length > 2 && NoMoreThanTwoTags())
                 throw new Search.TooManyTags();
             if (_format == UrlFormat.indexPhp)
             {
@@ -73,11 +73,11 @@ namespace BooruSharp.Booru
                 int max = int.Parse(xml.ChildNodes.Item(1).Attributes[0].InnerXml);
                 if (max == 0)
                     throw new Search.InvalidTags();
-                if (_maxLimit && max > 20001)
+                if (SearchIncreasedPostLimit() && max > 20001)
                     max = 20001;
                 return await GetSearchResultFromUrlAsync(CreateUrl(_imageUrl, "limit=1", TagsToString(tagsArg), "pid=" + _random.Next(0, max)));
             }
-            if (_noMoreThan2Tags)
+            if (NoMoreThanTwoTags())
                 return await GetSearchResultFromUrlAsync(CreateUrl(_imageUrl, "limit=1", TagsToString(tagsArg), "random=true")); // +order:random count as a tag so we use random=true instead to save one
             return await GetSearchResultFromUrlAsync(CreateUrl(_imageUrl, "limit=1", TagsToString(tagsArg)) + "+order:random");
         }
@@ -91,7 +91,7 @@ namespace BooruSharp.Booru
         {
             if (tagsArg == null) tagsArg = new string[0];
             else tagsArg = tagsArg.Where(x => !string.IsNullOrWhiteSpace(x)).ToArray();
-            if (tagsArg.Length > 2 && _noMoreThan2Tags)
+            if (tagsArg.Length > 2 && NoMoreThanTwoTags())
                 throw new Search.TooManyTags();
             if (_format == UrlFormat.indexPhp)
             {
@@ -101,7 +101,7 @@ namespace BooruSharp.Booru
                     return new[] { await GetRandomPostAsync(tagsArg) };
                 throw new Search.FeatureUnavailable();
             }
-            if (_noMoreThan2Tags)
+            if (NoMoreThanTwoTags())
                 return await GetSearchResultsFromUrlAsync(CreateUrl(_imageUrl, "limit=" + limit, TagsToString(tagsArg), "random=true")); // +order:random count as a tag so we use random=true instead to save one
             return await GetSearchResultsFromUrlAsync(CreateUrl(_imageUrl, "limit=" + limit, TagsToString(tagsArg)) + "+order:random");
         }

--- a/BooruSharp/Search/Related/ABooru.cs
+++ b/BooruSharp/Search/Related/ABooru.cs
@@ -14,7 +14,7 @@ namespace BooruSharp.Booru
         /// <param name="tag">The tag that the others must be related to</param>
         public virtual async Task<Search.Related.SearchResult[]> GetRelatedAsync(string tag)
         {
-            if (_relatedUrl == null)
+            if (!HasRelatedAPI())
                 throw new Search.FeatureUnavailable();
             if (tag == null)
                 throw new ArgumentNullException("Argument can't be null");

--- a/BooruSharp/Search/Tag/ABooru.cs
+++ b/BooruSharp/Search/Tag/ABooru.cs
@@ -28,7 +28,7 @@ namespace BooruSharp.Booru
         /// <param name="name">The ID of the tag you want information about</param>
         public virtual async Task<Search.Tag.SearchResult> GetTagAsync(int id)
         {
-            if (!_searchTagById)
+            if (!HasTagByIdAPI())
                 throw new Search.FeatureUnavailable();
             return await SearchTagAsync(null, id);
         }
@@ -48,7 +48,7 @@ namespace BooruSharp.Booru
                 urlTags.Add("limit=0");
             string url = CreateUrl(_tagUrl, urlTags.ToArray());
             Search.Tag.SearchResult[] results;
-            if (_tagUseXml)
+            if (TagsUseXml())
             {
                 var xml = await GetXmlAsync(url);
                 results = new Search.Tag.SearchResult[xml.LastChild.ChildNodes.Count];
@@ -83,7 +83,7 @@ namespace BooruSharp.Booru
             if (_format == UrlFormat.postIndexJson)
                 urlTags.Add("limit=0");
             string url = CreateUrl(_tagUrl, urlTags.ToArray());
-            if (_tagUseXml)
+            if (TagsUseXml())
             {
                 var xml = await GetXmlAsync(url);
                 foreach (var node in xml.LastChild)

--- a/BooruSharp/Search/Wiki/ABooru.cs
+++ b/BooruSharp/Search/Wiki/ABooru.cs
@@ -13,7 +13,7 @@ namespace BooruSharp.Booru
         /// <param name="query">The tag you want to get the wiki</param>
         public virtual async Task<Search.Wiki.SearchResult> GetWikiAsync(string query)
         {
-            if (_wikiUrl == null)
+            if (!HasWikiAPI())
                 throw new Search.FeatureUnavailable();
             if (query == null)
                 throw new ArgumentNullException("Argument can't be null");


### PR DESCRIPTION
This is a followup to #5.

- Replace all bool fields that used to store options with a BooruOptions field
Since `BooruOptions` acts as a bit field now, instead of storing multiple `bool` values for each option `ABooru` will now store all of them in a single `BooruOptions` field. The methods that previously returned `bool` fields now check for the set flags in the `BooruOptions` field.
- Add more methods for checking BooruOptions flags
The methods in question are `UsesHttp()`, `TagsUseXml()`, `CommentsUseXml()`, `NoMoreThanTwoTags()` and `SearchIncreasedPostLimit()`. They are `protected` for now but can be made `public` later to be in line with the rest of the similar methods.
- Everything that referenced bool fields before now calls methods instead
Classes that inherit `ABooru` and used to reference `bool` fields now use the methods above to achieve the same thing.
- Major cleanup of ABooru constructor
Simplified assignment of some URL related fields.