### PR TITLE
Complete public XML documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -332,3 +332,6 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+# XML documentation files
+xmldoc/

--- a/BooruSharp.Others/BooruSharp.Others.csproj
+++ b/BooruSharp.Others/BooruSharp.Others.csproj
@@ -13,7 +13,14 @@
     <RepositoryUrl>https://github.com/Xwilarg/BooruSharp</RepositoryUrl>
     <RepositoryType>Library</RepositoryType>
     <PackageTags>Image C-Sharp Pixiv</PackageTags>
+    <DocumentationFile>.\xmldoc\$(TargetFramework)\BooruSharp.Others.xml</DocumentationFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="xmldoc\**" />
+    <EmbeddedResource Remove="xmldoc\**" />
+    <None Remove="xmldoc\**" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/BooruSharp.Others/Pixiv.cs
+++ b/BooruSharp.Others/Pixiv.cs
@@ -30,8 +30,7 @@ namespace BooruSharp.Others
         }
 
         /// <summary>
-        /// Sends a login API request using specified
-        /// <paramref name="username"/> and <paramref name="password"/>.
+        /// Sends a login API request using specified user name and password.
         /// </summary>
         /// <param name="username">Pixiv user name.</param>
         /// <param name="password">Pixiv user password.</param>
@@ -87,7 +86,7 @@ namespace BooruSharp.Others
         }
 
         /// <summary>
-        /// Updates <see cref="AccessToken"/> using specified <paramref name="refreshToken"/>.
+        /// Sends a login API request using specified refresh token.
         /// </summary>
         /// <returns>The task object representing the asynchronous operation.</returns>
         /// <exception cref="AuthentificationInvalid"/>

--- a/BooruSharp.Others/Pixiv.cs
+++ b/BooruSharp.Others/Pixiv.cs
@@ -14,16 +14,39 @@ using System.Threading.Tasks;
 
 namespace BooruSharp.Others
 {
+    /// <summary>
+    /// Pixiv.
+    /// <para>https://www.pixiv.net/</para>
+    /// </summary>
     public class Pixiv : ABooru
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Pixiv"/> class.
+        /// </summary>
         public Pixiv() : base("app-api.pixiv.net", (UrlFormat)(-1), BooruOptions.noComment | BooruOptions.noLastComments | BooruOptions.noMultipleRandom |
                 BooruOptions.noPostByMd5 | BooruOptions.noRelated | BooruOptions.noTagById | BooruOptions.noWiki | BooruOptions.noEmptyPostSearch)
         {
             AccessToken = null;
         }
 
+        /// <summary>
+        /// Sends a login API request using specified
+        /// <paramref name="username"/> and <paramref name="password"/>.
+        /// </summary>
+        /// <param name="username">Pixiv user name.</param>
+        /// <param name="password">Pixiv user password.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentNullException"/>
+        /// <exception cref="AuthentificationInvalid"/>
+        /// <exception cref="HttpRequestException"/>
         public async Task LoginAsync(string username, string password)
         {
+            if (username == null)
+                throw new ArgumentNullException(nameof(username));
+
+            if (password == null)
+                throw new ArgumentNullException(nameof(password));
+
             var request = new HttpRequestMessage(HttpMethod.Post, "https://oauth.secure.pixiv.net/auth/token");
 
             string time = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss+00:00");
@@ -63,12 +86,24 @@ namespace BooruSharp.Others
             _refreshTime = DateTime.Now.AddSeconds(responseToken["expires_in"].Value<int>());
         }
 
+        /// <summary>
+        /// Updates <see cref="AccessToken"/> using specified <paramref name="refreshToken"/>.
+        /// </summary>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="AuthentificationInvalid"/>
+        /// <exception cref="HttpRequestException"/>
         public async Task LoginAsync(string refreshToken)
         {
             RefreshToken = refreshToken;
             await UpdateTokenAsync();
         }
 
+        /// <summary>
+        /// Downloads the <paramref name="result"/>'s image as an array of bytes.
+        /// </summary>
+        /// <param name="result">The post to get the image from.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="HttpRequestException"/>
         public async Task<byte[]> ImageToByteArrayAsync(SearchResult result)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, result.fileUrl);
@@ -81,6 +116,12 @@ namespace BooruSharp.Others
             return await response.Content.ReadAsByteArrayAsync();
         }
 
+        /// <summary>
+        /// Downloads the <paramref name="result"/>'s preview image as an array of bytes.
+        /// </summary>
+        /// <param name="result">The post to get the preview image from.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="HttpRequestException"/>
         public async Task<byte[]> PreviewToByteArrayAsync(SearchResult result)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, result.previewUrl);
@@ -93,6 +134,13 @@ namespace BooruSharp.Others
             return await response.Content.ReadAsByteArrayAsync();
         }
 
+        /// <summary>
+        /// Checks if the <see cref="AccessToken"/> needs to be updated,
+        /// and updates it if needed.
+        /// </summary>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="AuthentificationInvalid"/>
+        /// <exception cref="HttpRequestException"/>
         public async Task CheckUpdateTokenAsync()
         {
             if (DateTime.Now > _refreshTime)
@@ -126,9 +174,18 @@ namespace BooruSharp.Others
             _refreshTime = DateTime.Now.AddSeconds(responseToken["expires_in"].Value<int>());
         }
 
+        /// <inheritdoc/>
         public override bool IsSafe()
             => false;
 
+        /// <summary>
+        /// Adds a post with the specified ID to favorites.
+        /// </summary>
+        /// <param name="postId">The ID of the post to add to favorites.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="AuthentificationRequired"/>
+        /// <exception cref="HttpRequestException"/>
+        /// <exception cref="InvalidPostId"/>
         public override async Task AddFavoriteAsync(int postId)
         {
             if (AccessToken == null)
@@ -151,6 +208,14 @@ namespace BooruSharp.Others
             response.EnsureSuccessStatusCode();
         }
 
+        /// <summary>
+        /// Removes a post with the specified ID from favorites.
+        /// </summary>
+        /// <param name="postId">The ID of the post to remove from favorites.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="AuthentificationRequired"/>
+        /// <exception cref="HttpRequestException"/>
+        /// <exception cref="InvalidPostId"/>
         public override async Task RemoveFavoriteAsync(int postId)
         {
             if (AccessToken == null)
@@ -172,6 +237,7 @@ namespace BooruSharp.Others
             response.EnsureSuccessStatusCode();
         }
 
+        /// <inheritdoc/>
         public override async Task<SearchResult> GetPostByIdAsync(int id)
         {
             if (AccessToken == null)
@@ -193,6 +259,8 @@ namespace BooruSharp.Others
             return ParseSearchResult(jsonToken["illust"]);
         }
 
+        /// <inheritdoc/>
+        /// <exception cref="InvalidTags"/>
         public override async Task<SearchResult> GetRandomPostAsync(params string[] tagsArg)
         {
             // GetPostCountAsync already check for UpdateToken and if parameters are valid
@@ -218,6 +286,9 @@ namespace BooruSharp.Others
             return ParseSearchResult(jsonArray[0]);
         }
 
+        /// <inheritdoc/>
+        /// <exception cref="ArgumentException"/>
+        /// <exception cref="AuthentificationRequired"/>
         public override async Task<int> GetPostCountAsync(params string[] tagsArg)
         {
             if (AccessToken == null)
@@ -238,6 +309,10 @@ namespace BooruSharp.Others
             return jsonToken["body"]["illustManga"]["total"].Value<int>();
         }
 
+        /// <inheritdoc/>
+        /// <exception cref="ArgumentException"/>
+        /// <exception cref="AuthentificationRequired"/>
+        /// <exception cref="InvalidTags"/>
         public override async Task<SearchResult[]> GetLastPostsAsync(params string[] tagsArg)
         {
             if (AccessToken == null)
@@ -309,8 +384,15 @@ namespace BooruSharp.Others
                 null);
         }
 
-        public string AccessToken { private set; get; }
-        public string RefreshToken { private set; get; }
+        /// <summary>
+        /// Gets the access token associated with the current Pixiv session.
+        /// </summary>
+        public string AccessToken { get; private set; }
+
+        /// <summary>
+        /// Gets the refresh token associated with the current Pixiv session.
+        /// </summary>
+        public string RefreshToken { get; private set; }
 
         private DateTime _refreshTime;
 

--- a/BooruSharp/Booru/ABooru.cs
+++ b/BooruSharp/Booru/ABooru.cs
@@ -10,8 +10,15 @@ using System.Xml;
 
 namespace BooruSharp.Booru
 {
+    /// <summary>
+    /// Defines basic capabilities of a booru. This class is <see langword="abstract"/>.
+    /// </summary>
     public abstract partial class ABooru
     {
+        /// <summary>
+        /// Gets whether this booru is considered safe (that is, all posts on
+        /// this booru have rating of <see cref="Search.Post.Rating.Safe"/>).
+        /// </summary>
         public abstract bool IsSafe();
 
         private protected virtual Search.Comment.SearchResult GetCommentSearchResult(object json)
@@ -39,61 +46,60 @@ namespace BooruSharp.Booru
         // using properties for these kind of checks expresses the intent behind them more clearly.
 
         /// <summary>
-        /// Is it possible to search for related tag with this booru
+        /// Gets whether it is possible to search for related tags on this booru.
         /// </summary>
-        public bool HasRelatedAPI()
-            => !_options.HasFlag(BooruOptions.noRelated);
+        public bool HasRelatedAPI() => !_options.HasFlag(BooruOptions.noRelated);
+
         /// <summary>
-        /// Is it possible to search for wiki with this booru
+        /// Gets whether it is possible to search for wiki entries on this booru.
         /// </summary>
-        public bool HasWikiAPI()
-            => !_options.HasFlag(BooruOptions.noWiki);
+        public bool HasWikiAPI() => !_options.HasFlag(BooruOptions.noWiki);
+
         /// <summary>
-        /// Is it possible to search for comments with this booru
+        /// Gets whether it is possible to search for comments on this booru.
         /// </summary>
-        public bool HasCommentAPI()
-            => !_options.HasFlag(BooruOptions.noComment);
+        public bool HasCommentAPI() => !_options.HasFlag(BooruOptions.noComment);
+
         /// <summary>
-        /// Is it possible to search for tags using their ID with this booru
+        /// Gets whether it is possible to search for tags by their IDs on this booru.
         /// </summary>
-        public bool HasTagByIdAPI()
-            => !_options.HasFlag(BooruOptions.noTagById);
+        public bool HasTagByIdAPI() => !_options.HasFlag(BooruOptions.noTagById);
+
         /// <summary>
-        /// Is it possible to search for the lasts comments this booru
+        /// Gets whether it is possible to search for the last comments on this booru.
         /// </summary>
-        public bool HasSearchLastComment()
             // As a failsafe also check for the availability of comment API.
-            => HasCommentAPI() && !_options.HasFlag(BooruOptions.noLastComments);
+        public bool HasSearchLastComment() => HasCommentAPI() && !_options.HasFlag(BooruOptions.noLastComments);
+
         /// <summary>
-        /// Is it possible to search for posts using their MD5 with this booru
+        /// Gets whether it is possible to search for posts by their MD5 on this booru.
         /// </summary>
-        public bool HasPostByMd5API()
-            => !_options.HasFlag(BooruOptions.noPostByMd5);
+        public bool HasPostByMd5API() => !_options.HasFlag(BooruOptions.noPostByMd5);
+
         /// <summary>
-        /// Is it possible to search for posts using their ID with this booru
+        /// Gets whether it is possible to search for posts by their ID on this booru.
         /// </summary>
-        public bool HasPostByIdAPI()
-            => !_options.HasFlag(BooruOptions.noPostById);
+        public bool HasPostByIdAPI() => !_options.HasFlag(BooruOptions.noPostById);
+
         /// <summary>
-        /// Is it possible to get the total number of post
+        /// Gets whether it is possible to get the total number of posts on this booru.
         /// </summary>
-        public bool HasPostCountAPI()
-            => !_options.HasFlag(BooruOptions.noPostCount);
+        public bool HasPostCountAPI() => !_options.HasFlag(BooruOptions.noPostCount);
+
         /// <summary>
-        /// Is it possible to get multiple random images
+        /// Gets whether it is possible to get multiple random images on this booru.
         /// </summary>
-        public bool HasMultipleRandomAPI()
-            => !_options.HasFlag(BooruOptions.noMultipleRandom);
+        public bool HasMultipleRandomAPI() => !_options.HasFlag(BooruOptions.noMultipleRandom);
+
         /// <summary>
-        /// Is it possible to add/remove favorites
+        /// Gets whether this booru supports adding or removing favorite posts.
         /// </summary>
-        public bool HasFavoriteAPI()
-            => !_options.HasFlag(BooruOptions.noFavorite);
+        public bool HasFavoriteAPI() => !_options.HasFlag(BooruOptions.noFavorite);
+
         /// <summary>
-        /// Booru having this flag can't call post function without giving arguments
+        /// Gets whether this booru can't call post functions without search arguments.
         /// </summary>
-        public bool NoEmptyPostSearch()
-            => _options.HasFlag(BooruOptions.noEmptyPostSearch);
+        public bool NoEmptyPostSearch() => _options.HasFlag(BooruOptions.noEmptyPostSearch);
 
         /// <summary>
         /// Gets a value indicating whether http:// scheme is used instead of https://.
@@ -121,19 +127,31 @@ namespace BooruSharp.Booru
         protected bool SearchIncreasedPostLimit() => _options.HasFlag(BooruOptions.limitOf20000);
 
         /// <summary>
-        /// Is the booru available
+        /// Checks for the booru availability.
+        /// Throws <see cref="HttpRequestException"/> if service isn't available.
         /// </summary>
-        /// <exception cref="HttpRequestException">Service not available</exception>
         public async Task CheckAvailabilityAsync()
         {
             await HttpClient.SendAsync(new HttpRequestMessage(HttpMethod.Head, _imageUrl));
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ABooru"/> class.
+        /// </summary>
+        /// <param name="baseUrl">The base URL to use. This should be a host name.</param>
+        /// <param name="format">The URL format to use.</param>
+        /// <param name="options">The collection of option values.</param>
         [Obsolete(_deprecationMessage)]
         protected ABooru(string baseUrl, UrlFormat format, params BooruOptions[] options)
             : this(baseUrl, format, MergeOptions(options))
         { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ABooru"/> class.
+        /// </summary>
+        /// <param name="baseUrl">The base URL to use. This should be a host name.</param>
+        /// <param name="format">The URL format to use.</param>
+        /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
         protected ABooru(string baseUrl, UrlFormat format, BooruOptions options)
         {
             Auth = null;
@@ -267,8 +285,17 @@ namespace BooruSharp.Booru
             return options;
         }
 
+        /// <summary>
+        /// Gets or sets authentication credentials.
+        /// </summary>
         public BooruAuth Auth { set; get; } // Authentification
 
+        /// <summary>
+        /// Sets the <see cref="System.Net.Http.HttpClient"/> instance that will be used
+        /// to make requests. If <see langword="null"/> or left unset, the default
+        /// <see cref="System.Net.Http.HttpClient"/> instance will be used.
+        /// <para>This property can only be read in <see cref="ABooru"/> subclasses.</para>
+        /// </summary>
         public HttpClient HttpClient
         {
             protected get
@@ -287,17 +314,26 @@ namespace BooruSharp.Booru
             }
         }
 
+        /// <summary>
+        /// The instance of <see cref="Random"/> class used for generating random post IDs.
+        /// </summary>
+        protected static readonly Random _random = new Random();
+        /// <summary>
+        /// Contains a value indicating whether http:// scheme is used instead of https://.
+        /// </summary>
+        [Obsolete("UsesHttp method should be used instead.")]
+        protected readonly bool _useHttp; // Use http instead of https
+        /// <summary>
+        /// Contains the base request URL of this booru.
+        /// </summary>
+        protected readonly string _baseUrl;
+        // TODO: remove this message after removing obsolete constructors.
+        private protected const string _deprecationMessage = "Use a contructor that accepts single BooruOptions parameter. Use | (bitwise OR) operator to combine multiple options.";
         private HttpClient _client;
-        protected readonly string _baseUrl; // Booru's base URL
         private readonly string _imageUrlXml, _imageUrl, _tagUrl, _wikiUrl, _relatedUrl, _commentUrl; // URLs for differents endpoints
         // All options are stored in a bit field and can be retrieved using related methods/properties.
         private readonly BooruOptions _options;
         private readonly UrlFormat _format; // URL format
-        [Obsolete("UsesHttp property should be used instead.")]
-        protected readonly bool _useHttp; // Use http instead of https
-        protected static readonly Random _random = new Random();
-        // TODO: remove this message after removing obsolete constructors.
-        protected const string _deprecationMessage = "Use a contructor that accepts single BooruOptions parameter. Use | (bitwise OR) operator to combine multiple options.";
         private const string _userAgentHeaderValue = "Mozilla/5.0 BooruSharp";
         private static readonly Lazy<HttpClient> _lazyClient = new Lazy<HttpClient>(() =>
         {

--- a/BooruSharp/Booru/Atfbooru.cs
+++ b/BooruSharp/Booru/Atfbooru.cs
@@ -1,10 +1,18 @@
 ﻿namespace BooruSharp.Booru
 {
+    /// <summary>
+    /// All The Fallen.
+    /// <para>https://booru.allthefallen.moe/</para>
+    /// </summary>
     public sealed class Atfbooru : Template.Danbooru
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Atfbooru"/> class.
+        /// </summary>
         public Atfbooru() : base("booru.allthefallen.moe")
         { }
 
+        /// <inheritdoc/>
         public override bool IsSafe() => false;
     }
 }

--- a/BooruSharp/Booru/BooruAuth.cs
+++ b/BooruSharp/Booru/BooruAuth.cs
@@ -1,14 +1,32 @@
-﻿namespace BooruSharp.Booru
+﻿using System;
+
+namespace BooruSharp.Booru
 {
+    /// <summary>
+    /// Represents authentication credentials.
+    /// </summary>
     public class BooruAuth
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BooruAuth"/> class.
+        /// </summary>
+        /// <param name="userId">User ID.</param>
+        /// <param name="passwordHash">User password hash.</param>
+        /// <exception cref="ArgumentNullException"/>
         public BooruAuth(string userId, string passwordHash)
         {
-            UserId = userId;
-            PasswordHash = passwordHash;
+            UserId = userId ?? throw new ArgumentNullException(nameof(userId));
+            PasswordHash = passwordHash ?? throw new ArgumentNullException(nameof(passwordHash));
         }
 
-        public string UserId { private set; get; }
-        public string PasswordHash { private set; get; }
+        /// <summary>
+        /// Gets the user's ID.
+        /// </summary>
+        public string UserId { get; }
+
+        /// <summary>
+        /// Gets the user's password hash.
+        /// </summary>
+        public string PasswordHash { get; }
     }
 }

--- a/BooruSharp/Booru/BooruOptions.cs
+++ b/BooruSharp/Booru/BooruOptions.cs
@@ -2,27 +2,81 @@
 
 namespace BooruSharp.Booru
 {
+    /// <summary>
+    /// Represents options for creating an <see cref="ABooru"/> object.
+    /// <para>This enumeration has a <see cref="FlagsAttribute"/> attribute
+    /// that allows a bitwise combination of its member values.</para>
+    /// </summary>
     [Flags]
     public enum BooruOptions
     {
+        /// <summary>
+        /// Indicates that no additional options should be used when creating an <see cref="ABooru"/> object.
+        /// </summary>
         none = 0,
-        useHttp = 1 << 0, // http instead of https
-        // Missing API
+        /// <summary>
+        /// Indicates that http:// URI scheme should be used instead of https:// URI scheme.
+        /// </summary>
+        useHttp = 1 << 0,
+        /// <summary>
+        /// Indicates that wiki API is not available.
+        /// </summary>
         noWiki = 1 << 1,
+        /// <summary>
+        /// Indicates that related post API is not available.
+        /// </summary>
         noRelated = 1 << 2,
+        /// <summary>
+        /// Indicates that comments API is not available.
+        /// </summary>
         noComment = 1 << 3,
+        /// <summary>
+        /// Indicates that searching for tags by ID is not available.
+        /// </summary>
         noTagById = 1 << 4,
+        /// <summary>
+        /// Indicates that searching for posts by MD5 hash is not available.
+        /// </summary>
         noPostByMd5 = 1 << 5,
+        /// <summary>
+        /// Indicates that searching for posts by ID is not available.
+        /// </summary>
         noPostById = 1 << 6,
+        /// <summary>
+        /// Indicates that latest comments API is not available.
+        /// </summary>
         noLastComments = 1 << 7,
+        /// <summary>
+        /// Indicates that total post count API is not available.
+        /// </summary>
         noPostCount = 1 << 8,
+        /// <summary>
+        /// Indicates that retrieving multiple random posts API is not available.
+        /// </summary>
         noMultipleRandom = 1 << 9,
+        /// <summary>
+        /// Indicates that favoriting API is not available.
+        /// </summary>
         noFavorite = 1 << 10,
-        // API using XML instead of JSON
+        /// <summary>
+        /// Indicates that comments API respond with XML instead of JSON.
+        /// </summary>
         commentApiXml = 1 << 11,
+        /// <summary>
+        /// Indicates that tags API respond with XML instead of JSON.
+        /// </summary>
         tagApiXml = 1 << 12,
-        limitOf20000 = 1 << 13, // Limit of 20000 posts per search, used for Gelbooru
+        /// <summary>
+        /// Indicates that maximum limit of posts per search is increased.
+        /// </summary>
+        limitOf20000 = 1 << 13,
+        /// <summary>
+        /// Indicates that at most 2 tags can be used for post searching.
+        /// </summary>
         noMoreThan2Tags = 1 << 14,
-        noEmptyPostSearch = 1 << 15, // Post functions can't be called without tags
+        /// <summary>
+        /// Indicates that search parameter must be provided in order for post search functions to work.
+        /// </summary>
+        noEmptyPostSearch = 1 << 15,
     }
 }

--- a/BooruSharp/Booru/DanbooruDonmai.cs
+++ b/BooruSharp/Booru/DanbooruDonmai.cs
@@ -1,10 +1,18 @@
 ﻿namespace BooruSharp.Booru
 {
+    /// <summary>
+    /// Danbooru.
+    /// <para>https://danbooru.donmai.us/</para>
+    /// </summary>
     public sealed class DanbooruDonmai : Template.Danbooru
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DanbooruDonmai"/> class.
+        /// </summary>
         public DanbooruDonmai() : base("danbooru.donmai.us", BooruOptions.noMoreThan2Tags)
         { }
 
+        /// <inheritdoc/>
         public override bool IsSafe() => false;
     }
 }

--- a/BooruSharp/Booru/E621.cs
+++ b/BooruSharp/Booru/E621.cs
@@ -1,10 +1,18 @@
 ﻿namespace BooruSharp.Booru
 {
+    /// <summary>
+    /// E621.
+    /// <para>https://e621.net/</para>
+    /// </summary>
     public sealed class E621 : Template.E621
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="E621"/> class.
+        /// </summary>
         public E621() : base("e621.net")
         { }
 
+        /// <inheritdoc/>
         public override bool IsSafe() => false;
     }
 }

--- a/BooruSharp/Booru/E926.cs
+++ b/BooruSharp/Booru/E926.cs
@@ -1,14 +1,22 @@
 ﻿namespace BooruSharp.Booru
 {
+    /// <summary>
+    /// E926.
+    /// <para>https://e926.net/</para>
+    /// </summary>
     public sealed class E926 : Template.E621
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="E926"/> class.
+        /// </summary>
         public E926() : base("e926.net")
         { }
 
-        /// <summary>
-        /// E926 can provide images with an explicit rating, but the URL of the file will be null
-        /// </summary>
-        /// <returns></returns>
+        /// <inheritdoc/>
+        /// <remarks>
+        /// <see cref="E926"/> can provide images with an explicit rating,
+        /// but the URL of the file will be <see langword="null"/>.
+        /// </remarks>
         public override bool IsSafe() => true;
     }
 }

--- a/BooruSharp/Booru/Furrybooru.cs
+++ b/BooruSharp/Booru/Furrybooru.cs
@@ -1,10 +1,18 @@
 ﻿namespace BooruSharp.Booru
 {
+    /// <summary>
+    /// FurryBooru.
+    /// <para>https://furry.booru.org/</para>
+    /// </summary>
     public sealed class Furrybooru : Template.Gelbooru02
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Furrybooru"/> class.
+        /// </summary>
         public Furrybooru() : base("furry.booru.org", BooruOptions.useHttp)
         { }
 
+        /// <inheritdoc/>
         public override bool IsSafe() => false;
     }
 }

--- a/BooruSharp/Booru/Gelbooru.cs
+++ b/BooruSharp/Booru/Gelbooru.cs
@@ -1,10 +1,18 @@
 ﻿namespace BooruSharp.Booru
 {
+    /// <summary>
+    /// Gelbooru.
+    /// <para>https://gelbooru.com/</para>
+    /// </summary>
     public sealed class Gelbooru : Template.Gelbooru
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Gelbooru"/> class.
+        /// </summary>
         public Gelbooru() : base("gelbooru.com")
         { }
 
+        /// <inheritdoc/>
         public override bool IsSafe() => false;
     }
 }

--- a/BooruSharp/Booru/Konachan.cs
+++ b/BooruSharp/Booru/Konachan.cs
@@ -1,10 +1,18 @@
 ﻿namespace BooruSharp.Booru
 {
+    /// <summary>
+    /// Konachan.
+    /// <para>https://konachan.com/</para>
+    /// </summary>
     public sealed class Konachan : Template.Moebooru
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Konachan"/> class.
+        /// </summary>
         public Konachan() : base("konachan.com")
         { }
 
+        /// <inheritdoc/>
         public override bool IsSafe() => false;
     }
 }

--- a/BooruSharp/Booru/Lolibooru.cs
+++ b/BooruSharp/Booru/Lolibooru.cs
@@ -2,11 +2,19 @@
 
 namespace BooruSharp.Booru
 {
+    /// <summary>
+    /// Lolibooru.
+    /// <para>https://lolibooru.moe/</para>
+    /// </summary>
     public sealed class Lolibooru : Template.Moebooru
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Lolibooru"/> class.
+        /// </summary>
         public Lolibooru() : base("lolibooru.moe")
         { }
 
+        /// <inheritdoc/>
         public override bool IsSafe() => false;
 
         private protected override Search.Tag.SearchResult GetTagSearchResult(object json)

--- a/BooruSharp/Booru/Realbooru.cs
+++ b/BooruSharp/Booru/Realbooru.cs
@@ -1,10 +1,18 @@
 ﻿namespace BooruSharp.Booru
 {
+    /// <summary>
+    /// Realbooru.
+    /// <para>http://realbooru.com/</para>
+    /// </summary>
     public sealed class Realbooru : Template.Gelbooru02
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Realbooru"/> class.
+        /// </summary>
         public Realbooru() : base("realbooru.com")
         { }
 
+        /// <inheritdoc/>
         public override bool IsSafe() => false;
     }
 }

--- a/BooruSharp/Booru/Rule34.cs
+++ b/BooruSharp/Booru/Rule34.cs
@@ -1,10 +1,18 @@
 ﻿namespace BooruSharp.Booru
 {
+    /// <summary>
+    /// Rule 34.
+    /// <para>https://rule34.xxx/</para>
+    /// </summary>
     public sealed class Rule34 : Template.Gelbooru02
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Rule34"/> class.
+        /// </summary>
         public Rule34() : base("rule34.xxx", BooruOptions.noComment | BooruOptions.limitOf20000) // The limit is in fact 200000 but search with tags make it incredibly hard to know what is really your pid
         { }
 
+        /// <inheritdoc/>
         public override bool IsSafe() => false;
     }
 }

--- a/BooruSharp/Booru/Safebooru.cs
+++ b/BooruSharp/Booru/Safebooru.cs
@@ -1,10 +1,18 @@
 ﻿namespace BooruSharp.Booru
 {
+    /// <summary>
+    /// Safebooru.
+    /// <para>https://safebooru.org/</para>
+    /// </summary>
     public sealed class Safebooru : Template.Gelbooru02
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Safebooru"/> class.
+        /// </summary>
         public Safebooru() : base("safebooru.org", BooruOptions.noComment)
         { }
 
+        /// <inheritdoc/>
         public override bool IsSafe() => true;
     }
 }

--- a/BooruSharp/Booru/Sakugabooru.cs
+++ b/BooruSharp/Booru/Sakugabooru.cs
@@ -1,10 +1,18 @@
 ﻿namespace BooruSharp.Booru
 {
+    /// <summary>
+    /// Sakugabooru.
+    /// <para>https://www.sakugabooru.com/</para>
+    /// </summary>
     public sealed class Sakugabooru : Template.Moebooru
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Sakugabooru"/> class.
+        /// </summary>
         public Sakugabooru() : base("sakugabooru.com", BooruOptions.noLastComments)
         { }
 
+        /// <inheritdoc/>
         public override bool IsSafe() => false;
     }
 }

--- a/BooruSharp/Booru/SankakuComplex.cs
+++ b/BooruSharp/Booru/SankakuComplex.cs
@@ -2,7 +2,7 @@
 {
     /// <summary>
     /// Sankaku Complex.
-    /// <para>https://chan.sankakucomplex.com/</para>
+    /// <para>https://beta.sankakucomplex.com/</para>
     /// </summary>
     public class SankakuComplex : Template.Sankaku
     {

--- a/BooruSharp/Booru/SankakuComplex.cs
+++ b/BooruSharp/Booru/SankakuComplex.cs
@@ -1,10 +1,18 @@
 ﻿namespace BooruSharp.Booru
 {
+    /// <summary>
+    /// Sankaku Complex.
+    /// <para>https://chan.sankakucomplex.com/</para>
+    /// </summary>
     public class SankakuComplex : Template.Sankaku
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SankakuComplex"/> class.
+        /// </summary>
         public SankakuComplex() : base("capi-v2.sankakucomplex.com")
         { }
 
+        /// <inheritdoc/>
         public override bool IsSafe() => false;
     }
 }

--- a/BooruSharp/Booru/Template/Danbooru.cs
+++ b/BooruSharp/Booru/Template/Danbooru.cs
@@ -4,12 +4,25 @@ using System.Linq;
 
 namespace BooruSharp.Booru.Template
 {
+    /// <summary>
+    /// Template booru based on Danbooru. This class is <see langword="abstract"/>.
+    /// </summary>
     public abstract class Danbooru : ABooru
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Danbooru"/> template class.
+        /// </summary>
+        /// <param name="url">The base URL to use. This should be a host name.</param>
+        /// <param name="options">The collection of option values.</param>
         [Obsolete(_deprecationMessage)]
         public Danbooru(string url, params BooruOptions[] options) : this(url, MergeOptions(options))
         { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Danbooru"/> template class.
+        /// </summary>
+        /// <param name="url">The base URL to use. This should be a host name.</param>
+        /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
         public Danbooru(string url, BooruOptions options = BooruOptions.none) : base(url, UrlFormat.danbooru, options | BooruOptions.noLastComments | BooruOptions.noPostCount | BooruOptions.noFavorite)
         { }
 

--- a/BooruSharp/Booru/Template/E621.cs
+++ b/BooruSharp/Booru/Template/E621.cs
@@ -1,16 +1,28 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace BooruSharp.Booru.Template
 {
+    /// <summary>
+    /// Template booru based on E621. This class is <see langword="abstract"/>.
+    /// </summary>
     public abstract class E621 : ABooru
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="E621"/> template class.
+        /// </summary>
+        /// <param name="url">The base URL to use. This should be a host name.</param>
+        /// <param name="options">The collection of option values.</param>
         [Obsolete(_deprecationMessage)]
         public E621(string url, params BooruOptions[] options) : this(url, MergeOptions(options))
         { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="E621"/> template class.
+        /// </summary>
+        /// <param name="url">The base URL to use. This should be a host name.</param>
+        /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
         public E621(string url, BooruOptions options = BooruOptions.none) : base(url, UrlFormat.danbooru, options | BooruOptions.noWiki | BooruOptions.noRelated | BooruOptions.noComment | BooruOptions.noTagById | BooruOptions.noPostById | BooruOptions.noPostCount | BooruOptions.noFavorite)
         { }
 

--- a/BooruSharp/Booru/Template/Gelbooru.cs
+++ b/BooruSharp/Booru/Template/Gelbooru.cs
@@ -10,18 +10,29 @@ using System.Xml;
 namespace BooruSharp.Booru.Template
 {
     /// <summary>
-    /// Gelbooru 0.2
+    /// Template booru based on Gelbooru. This class is <see langword="abstract"/>.
     /// </summary>
     public abstract class Gelbooru : ABooru
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Gelbooru"/> template class.
+        /// </summary>
+        /// <param name="url">The base URL to use. This should be a host name.</param>
+        /// <param name="options">The collection of option values.</param>
         [Obsolete(_deprecationMessage)]
         public Gelbooru(string url, params BooruOptions[] options) : this(url, MergeOptions(options))
         { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Gelbooru"/> template class.
+        /// </summary>
+        /// <param name="url">The base URL to use. This should be a host name.</param>
+        /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
         public Gelbooru(string url, BooruOptions options = BooruOptions.none) : base(url, UrlFormat.indexPhp, options |
              BooruOptions.noWiki | BooruOptions.noRelated | BooruOptions.limitOf20000 | BooruOptions.commentApiXml)
         { }
 
+        /// <inheritdoc/>
         public async override Task<Search.Post.SearchResult> GetPostByMd5Async(string md5)
         {
             if (md5 == null)

--- a/BooruSharp/Booru/Template/Gelbooru02.cs
+++ b/BooruSharp/Booru/Template/Gelbooru02.cs
@@ -7,14 +7,24 @@ using System.Xml;
 namespace BooruSharp.Booru.Template
 {
     /// <summary>
-    /// Gelbooru 0.2
+    /// Template booru based on Gelbooru 0.2. This class is <see langword="abstract"/>.
     /// </summary>
     public abstract class Gelbooru02 : ABooru
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Gelbooru02"/> template class.
+        /// </summary>
+        /// <param name="url">The base URL to use. This should be a host name.</param>
+        /// <param name="options">The collection of option values.</param>
         [Obsolete(_deprecationMessage)]
         public Gelbooru02(string url, params BooruOptions[] options) : this(url, MergeOptions(options))
         { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Gelbooru02"/> template class.
+        /// </summary>
+        /// <param name="url">The base URL to use. This should be a host name.</param>
+        /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
         public Gelbooru02(string url, BooruOptions options = BooruOptions.none) : base(url, UrlFormat.indexPhp, options |
              BooruOptions.noRelated | BooruOptions.noWiki | BooruOptions.noPostByMd5 | BooruOptions.commentApiXml | BooruOptions.tagApiXml | BooruOptions.noMultipleRandom)
         {

--- a/BooruSharp/Booru/Template/Moebooru.cs
+++ b/BooruSharp/Booru/Template/Moebooru.cs
@@ -4,12 +4,25 @@ using System.Linq;
 
 namespace BooruSharp.Booru.Template
 {
+    /// <summary>
+    /// Template booru based on Moebooru. This class is <see langword="abstract"/>.
+    /// </summary>
     public abstract class Moebooru : ABooru
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Moebooru"/> template class.
+        /// </summary>
+        /// <param name="url">The base URL to use. This should be a host name.</param>
+        /// <param name="options">The collection of option values.</param>
         [Obsolete(_deprecationMessage)]
         public Moebooru(string url, params BooruOptions[] options) : this(url, MergeOptions(options))
         { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Moebooru"/> template class.
+        /// </summary>
+        /// <param name="url">The base URL to use. This should be a host name.</param>
+        /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
         public Moebooru(string url, BooruOptions options = BooruOptions.none) : base(url, UrlFormat.postIndexJson, options | BooruOptions.noPostByMd5 | BooruOptions.noPostById | BooruOptions.noFavorite)
         { }
 

--- a/BooruSharp/Booru/Template/Sankaku.cs
+++ b/BooruSharp/Booru/Template/Sankaku.cs
@@ -1,16 +1,28 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace BooruSharp.Booru.Template
 {
+    /// <summary>
+    /// Template booru based on Sankaku. This class is <see langword="abstract"/>.
+    /// </summary>
     public abstract class Sankaku : ABooru
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Sankaku"/> template class.
+        /// </summary>
+        /// <param name="url">The base URL to use. This should be a host name.</param>
+        /// <param name="options">The collection of option values.</param>
         [Obsolete(_deprecationMessage)]
         public Sankaku(string url, params BooruOptions[] options) : this(url, MergeOptions(options))
         { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Sankaku"/> template class.
+        /// </summary>
+        /// <param name="url">The base URL to use. This should be a host name.</param>
+        /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
         public Sankaku(string url, BooruOptions options = BooruOptions.none) : base(url, UrlFormat.sankaku, options | BooruOptions.noRelated | BooruOptions.noPostByMd5 | BooruOptions.noPostById | BooruOptions.noPostCount | BooruOptions.noFavorite | BooruOptions.noTagById)
         { }
 

--- a/BooruSharp/Booru/UrlFormat.cs
+++ b/BooruSharp/Booru/UrlFormat.cs
@@ -6,19 +6,19 @@
     public enum UrlFormat
     {
         /// <summary>
-        /// <c>post/index.json</c>
+        /// Indicates that the API uses <c>/post/index.json</c> query scheme.
         /// </summary>
         postIndexJson,
         /// <summary>
-        /// <c>index.php?page=dapi&amp;s=post&amp;q=index&amp;json=1</c>
+        /// Indicates that the API uses <c>/index.php?page=dapi&amp;s=post&amp;q=index&amp;json=1</c> query scheme.
         /// </summary>
         indexPhp,
         /// <summary>
-        /// <c>posts.json</c>
+        /// Indicates that the API uses <c>/posts.json</c> query scheme.
         /// </summary>
         danbooru,
         /// <summary>
-        /// <c>posts</c>
+        /// Indicates that the API uses <c>/posts</c> query scheme.
         /// </summary>
         sankaku
     }

--- a/BooruSharp/Booru/UrlFormat.cs
+++ b/BooruSharp/Booru/UrlFormat.cs
@@ -1,10 +1,25 @@
 ﻿namespace BooruSharp.Booru
 {
+    /// <summary>
+    /// Indicates the API URL format that will be used to create API requests.
+    /// </summary>
     public enum UrlFormat
     {
-        postIndexJson, //post/index.json
-        indexPhp, // index.php?page=dapi&s=post&q=index&json=1
-        danbooru, // posts.json
-        sankaku // posts
+        /// <summary>
+        /// <c>post/index.json</c>
+        /// </summary>
+        postIndexJson,
+        /// <summary>
+        /// <c>index.php?page=dapi&amp;s=post&amp;q=index&amp;json=1</c>
+        /// </summary>
+        indexPhp,
+        /// <summary>
+        /// <c>posts.json</c>
+        /// </summary>
+        danbooru,
+        /// <summary>
+        /// <c>posts</c>
+        /// </summary>
+        sankaku
     }
 }

--- a/BooruSharp/Booru/Xbooru.cs
+++ b/BooruSharp/Booru/Xbooru.cs
@@ -1,10 +1,18 @@
 ﻿namespace BooruSharp.Booru
 {
+    /// <summary>
+    /// Xbooru.
+    /// <para>https://xbooru.com/</para>
+    /// </summary>
     public sealed class Xbooru : Template.Gelbooru02
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Xbooru"/> class.
+        /// </summary>
         public Xbooru() : base("xbooru.com")
         { }
 
+        /// <inheritdoc/>
         public override bool IsSafe() => false;
     }
 }

--- a/BooruSharp/Booru/Yandere.cs
+++ b/BooruSharp/Booru/Yandere.cs
@@ -1,10 +1,18 @@
 ﻿namespace BooruSharp.Booru
 {
+    /// <summary>
+    /// Yande.re.
+    /// <para>https://yande.re/post</para>
+    /// </summary>
     public sealed class Yandere : Template.Moebooru
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Yandere"/> class.
+        /// </summary>
         public Yandere() : base("yande.re", BooruOptions.noLastComments)
         { }
 
+        /// <inheritdoc/>
         public override bool IsSafe() => false;
     }
 }

--- a/BooruSharp/Booru/Yandere.cs
+++ b/BooruSharp/Booru/Yandere.cs
@@ -2,7 +2,7 @@
 {
     /// <summary>
     /// Yande.re.
-    /// <para>https://yande.re/post</para>
+    /// <para>https://yande.re/</para>
     /// </summary>
     public sealed class Yandere : Template.Moebooru
     {

--- a/BooruSharp/BooruSharp.csproj
+++ b/BooruSharp/BooruSharp.csproj
@@ -14,7 +14,14 @@
     <RepositoryType>Library</RepositoryType>
     <PackageReleaseNotes>Internal changes on HttpClient (#6), Improvements in BooruSharp.Others (#7, #8)</PackageReleaseNotes>
     <PackageTags>Booru Gelbooru Image C-Sharp Atfbooru DanbooruDonmai Danbooru E621 E926 FurryBooru Konachan Lolibooru Realbooru Rule34 SankakuComplex Safebooru Sakugabooru Xbooru Yandere</PackageTags>
+    <DocumentationFile>.\xmldoc\$(TargetFramework)\BooruSharp.xml</DocumentationFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="xmldoc\**" />
+    <EmbeddedResource Remove="xmldoc\**" />
+    <None Remove="xmldoc\**" />
+  </ItemGroup>
 
   <ItemGroup>
     <None Include="..\LICENSE">

--- a/BooruSharp/Search/AuthentificationInvalid.cs
+++ b/BooruSharp/Search/AuthentificationInvalid.cs
@@ -2,8 +2,15 @@
 
 namespace BooruSharp.Search
 {
+    /// <summary>
+    /// Represents errors that occur whenever a method that requires
+    /// authentication credentials is called with invalid credentials.
+    /// </summary>
     public class AuthentificationInvalid : Exception
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthentificationInvalid"/> class.
+        /// </summary>
         public AuthentificationInvalid() : base("Your credentials are invalid")
         { }
     }

--- a/BooruSharp/Search/AuthentificationRequired.cs
+++ b/BooruSharp/Search/AuthentificationRequired.cs
@@ -2,8 +2,15 @@
 
 namespace BooruSharp.Search
 {
+    /// <summary>
+    /// Represents errors that occur whenever a method that requires
+    /// authentication credentials is called with no credentials.
+    /// </summary>
     public class AuthentificationRequired : Exception
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthentificationRequired"/> class.
+        /// </summary>
         public AuthentificationRequired() : base("Authentification is required for this feature")
         { }
     }

--- a/BooruSharp/Search/Comment/ABooru.cs
+++ b/BooruSharp/Search/Comment/ABooru.cs
@@ -9,9 +9,12 @@ namespace BooruSharp.Booru
     public abstract partial class ABooru
     {
         /// <summary>
-        /// Get the comments posted on a post
+        /// Get the comments posted on a post.
         /// </summary>
-        /// <param name="postId">The ID of the post to get information about</param>
+        /// <param name="postId">The ID of the post to get information about.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="Search.FeatureUnavailable"/>
+        /// <exception cref="System.Net.Http.HttpRequestException"/>
         public virtual async Task<Search.Comment.SearchResult[]> GetCommentsAsync(int postId)
         {
             if (!HasCommentAPI())
@@ -49,8 +52,11 @@ namespace BooruSharp.Booru
         }
 
         /// <summary>
-        /// Get the lasts comments posted on the website
+        /// Get the last comments posted on the website.
         /// </summary>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="Search.FeatureUnavailable"/>
+        /// <exception cref="System.Net.Http.HttpRequestException"/>
         public virtual async Task<Search.Comment.SearchResult[]> GetLastCommentsAsync()
         {
             if (!HasSearchLastComment())

--- a/BooruSharp/Search/Comment/SearchResult.cs
+++ b/BooruSharp/Search/Comment/SearchResult.cs
@@ -2,8 +2,21 @@
 
 namespace BooruSharp.Search.Comment
 {
+    /// <summary>
+    /// Represents a comment API search result.
+    /// </summary>
     public struct SearchResult
     {
+        /// <summary>
+        /// Initializes a <see cref="SearchResult"/> struct. 
+        /// </summary>
+        /// <param name="commentId">The ID of the comment.</param>
+        /// <param name="postId">The ID of the image associated with the comment</param>
+        /// <param name="authorId">The ID of the author of the comment, or
+        /// <see langword="null"/> if the author is anonymous.</param>
+        /// <param name="creation">The date when the comment was posted.</param>
+        /// <param name="authorName">The name of the author of the comment.</param>
+        /// <param name="body">The comment's message.</param>
         public SearchResult(int commentId, int postId, int? authorId, DateTime creation, string authorName, string body)
         {
             this.commentId = commentId;
@@ -15,32 +28,33 @@ namespace BooruSharp.Search.Comment
         }
 
         /// <summary>
-        /// Id of the comment
+        /// Gets the ID of the comment.
         /// </summary>
         public readonly int commentId;
 
         /// <summary>
-        /// Id of the image associated with the comment
+        /// Gets the ID of the image associated with the comment.
         /// </summary>
         public readonly int postId;
 
         /// <summary>
-        /// Id of the author of the comment, is null if the author is anonymous
+        /// Gets the ID of the author of the comment, or
+        /// <see langword="null"/> if the author is anonymous.
         /// </summary>
         public readonly int? authorId;
 
         /// <summary>
-        /// When the comment was posted
+        /// Gets the date when the comment was posted.
         /// </summary>
         public readonly DateTime creation;
 
         /// <summary>
-        /// Name of the author of the comment
+        /// Gets the name of the author of the comment.
         /// </summary>
         public readonly string authorName;
 
         /// <summary>
-        /// Comment's message
+        /// Gets the comment's message.
         /// </summary>
         public readonly string body;
     }

--- a/BooruSharp/Search/Favorite/ABooru.cs
+++ b/BooruSharp/Search/Favorite/ABooru.cs
@@ -8,12 +8,18 @@ namespace BooruSharp.Booru
     public abstract partial class ABooru
     {
         /// <summary>
-        /// Add a post to your favorite
+        /// Adds a post to your favorites.
         /// </summary>
         /// <remarks>
-        /// You must login using SetBooruAuth before using this function
+        /// You must login using <see cref="Auth"/> property before calling this method.
         /// </remarks>
-        /// <param name="postId">The ID of the post you want to add to your favorite</param>
+        /// <param name="postId">The ID of the post you want to add to your favorites.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="AuthentificationInvalid"/>
+        /// <exception cref="AuthentificationRequired"/>
+        /// <exception cref="FeatureUnavailable"/>
+        /// <exception cref="System.Net.Http.HttpRequestException"/>
+        /// <exception cref="InvalidPostId"/>
         public virtual async Task AddFavoriteAsync(int postId)
         {
             if (!HasFavoriteAPI())
@@ -35,12 +41,17 @@ namespace BooruSharp.Booru
         }
 
         /// <summary>
-        /// Remove a post from your favorite
+        /// Removes a post from your favorites.
         /// </summary>
         /// <remarks>
-        /// You must login using SetBooruAuth before using this function
+        /// You must login using <see cref="Auth"/> property before calling this method.
         /// </remarks>
-        /// <param name="postId">The ID of the post you want to remove from your favorite</param>
+        /// <param name="postId">The ID of the post you want to remove from your favorites.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="AuthentificationInvalid"/>
+        /// <exception cref="AuthentificationRequired"/>
+        /// <exception cref="FeatureUnavailable"/>
+        /// <exception cref="System.Net.Http.HttpRequestException"/>
         public virtual async Task RemoveFavoriteAsync(int postId)
         {
             if (!HasFavoriteAPI())

--- a/BooruSharp/Search/FeatureUnavailable.cs
+++ b/BooruSharp/Search/FeatureUnavailable.cs
@@ -2,8 +2,15 @@
 
 namespace BooruSharp.Search
 {
+    /// <summary>
+    /// Represents errors that occur whenever a method that requires
+    /// certain booru features (such as tag wiki API) is called.
+    /// </summary>
     public class FeatureUnavailable : Exception
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FeatureUnavailable"/> class.
+        /// </summary>
         public FeatureUnavailable() : base("This feature isn't available for this Booru")
         { }
     }

--- a/BooruSharp/Search/InvalidPostId.cs
+++ b/BooruSharp/Search/InvalidPostId.cs
@@ -1,10 +1,22 @@
 ﻿namespace BooruSharp.Search
 {
+    /// <summary>
+    /// Represents errors that occur whenever a method that requires a
+    /// post ID to perform an API request is called with the invalid ID.
+    /// </summary>
     public class InvalidPostId : System.ArgumentException
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidPostId"/>
+        /// class with a specified error message.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
         public InvalidPostId(string message) : base(message)
         { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidPostId"/> class.
+        /// </summary>
         public InvalidPostId() : base("There is no post with this id")
         { }
     }

--- a/BooruSharp/Search/InvalidTags.cs
+++ b/BooruSharp/Search/InvalidTags.cs
@@ -1,7 +1,14 @@
 ﻿namespace BooruSharp.Search
 {
+    /// <summary>
+    /// Represents errors that occur whenever a method that requires a
+    /// tag query to perform an API request is called with the invalid query.
+    /// </summary>
     public class InvalidTags : System.ArgumentException
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidTags"/> class.
+        /// </summary>
         public InvalidTags() : base("There is nothing available with these tags")
         { }
     }

--- a/BooruSharp/Search/Post/ABooru.cs
+++ b/BooruSharp/Search/Post/ABooru.cs
@@ -9,9 +9,13 @@ namespace BooruSharp.Booru
     public abstract partial class ABooru
     {
         /// <summary>
-        /// Search for a post using its MD5
+        /// Searches for a post using its MD5 hash.
         /// </summary>
-        /// <param name="md5">The MD5 of the post to search</param>
+        /// <param name="md5">The MD5 hash of the post to search.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentNullException"/>
+        /// <exception cref="Search.FeatureUnavailable"/>
+        /// <exception cref="System.Net.Http.HttpRequestException"/>
         public virtual async Task<Search.Post.SearchResult> GetPostByMd5Async(string md5)
         {
             if (!HasPostByMd5API())
@@ -24,10 +28,12 @@ namespace BooruSharp.Booru
         }
 
         /// <summary>
-        /// Search for a post using its ID
+        /// Searches for a post using its ID.
         /// </summary>
-        /// <param name="id">The ID fo the post to search</param>
-        /// <returns></returns>
+        /// <param name="id">The ID of the post to search.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="Search.FeatureUnavailable"/>
+        /// <exception cref="System.Net.Http.HttpRequestException"/>
         public virtual async Task<Search.Post.SearchResult> GetPostByIdAsync(int id)
         {
             if (!HasPostByIdAPI())
@@ -39,9 +45,14 @@ namespace BooruSharp.Booru
         }
 
         /// <summary>
-        /// Get the number of posts available
+        /// Gets the total number of available posts. If <paramref name="tagsArg"/> array is specified
+        /// and isn't empty, the total number of posts containing these tags will be returned.
         /// </summary>
-        /// <param name="tagsArg">Tags for which you want the number of posts about (optional)</param>
+        /// <param name="tagsArg">The optional array of tags.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="Search.FeatureUnavailable"/>
+        /// <exception cref="System.Net.Http.HttpRequestException"/>
+        /// <exception cref="Search.TooManyTags"/>
         public virtual async Task<int> GetPostCountAsync(params string[] tagsArg)
         {
             if (!HasPostCountAPI())
@@ -59,9 +70,13 @@ namespace BooruSharp.Booru
         }
 
         /// <summary>
-        /// Search for a random post
+        /// Searches for a random post. If <paramref name="tagsArg"/> array is specified
+        /// and isn't empty, random post containing those tags will be returned.
         /// </summary>
-        /// <param name="tagsArg">Tags that must be contained in the post (optional)</param>
+        /// <param name="tagsArg">The optional array of tags that must be contained in the post.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="System.Net.Http.HttpRequestException"/>
+        /// <exception cref="Search.TooManyTags"/>
         public virtual async Task<Search.Post.SearchResult> GetRandomPostAsync(params string[] tagsArg)
         {
             string[] tags = tagsArg != null
@@ -99,10 +114,15 @@ namespace BooruSharp.Booru
         }
 
         /// <summary>
-        /// Search for random posts
+        /// Searches for multiple random posts. If <paramref name="tagsArg"/> array is
+        /// specified and isn't empty, random posts containing those tags will be returned.
         /// </summary>
-        /// <param name="limit">Number of posts you want to get</param>
-        /// <param name="tagsArg">Tags that must be contained in the post (optional)</param>
+        /// <param name="limit">The number of posts to get.</param>
+        /// <param name="tagsArg">The optional array of tags that must be contained in the posts.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="Search.FeatureUnavailable"/>
+        /// <exception cref="System.Net.Http.HttpRequestException"/>
+        /// <exception cref="Search.TooManyTags"/>
         public virtual async Task<Search.Post.SearchResult[]> GetRandomPostsAsync(int limit, params string[] tagsArg)
         {
             if (!HasMultipleRandomAPI())
@@ -124,9 +144,12 @@ namespace BooruSharp.Booru
         }
 
         /// <summary>
-        /// Get the latest posts of the website
+        /// Gets the latest posts on the website. If <paramref name="tagsArg"/> array is
+        /// specified and isn't empty, latest posts containing those tags will be returned.
         /// </summary>
-        /// <param name="tagsArg">Tags that must be contained in the post (optional)</param>
+        /// <param name="tagsArg">The optional array of tags that must be contained in the posts.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="System.Net.Http.HttpRequestException"/>
         public virtual async Task<Search.Post.SearchResult[]> GetLastPostsAsync(params string[] tagsArg)
         {
             return GetPostsSearchResult(JsonConvert.DeserializeObject(await GetJsonAsync(CreateUrl(_imageUrl, TagsToString(tagsArg)))));
@@ -143,7 +166,7 @@ namespace BooruSharp.Booru
         }
 
         /// <summary>
-        /// Convert letter to its maching Search.Post.Rating
+        /// Converts a letter to its maching <see cref="Search.Post.Rating"/>.
         /// </summary>
         protected Search.Post.Rating GetRating(char c)
         {

--- a/BooruSharp/Search/Post/Rating.cs
+++ b/BooruSharp/Search/Post/Rating.cs
@@ -1,9 +1,24 @@
 ﻿namespace BooruSharp.Search.Post
 {
+    // Rating descriptions are taken from:
+    // https://danbooru.donmai.us/wiki_pages/howto%3Arate
+    /// <summary>
+    /// Represents a level of explicit content of the post.
+    /// </summary>
     public enum Rating
     {
+        /// <summary>
+        /// Indicates that post cannot be considered either questionable or explicit.
+        /// Note that safe does not mean safe for work and may still include "sexy" content.
+        /// </summary>
         Safe,
+        /// <summary>
+        /// Indicates that post may contain some non-explicit nudity or sexual content, but isn't quite pornographic.
+        /// </summary>
         Questionable,
+        /// <summary>
+        /// Indicates that post contains explicit sex, gratuitously exposed genitals, or it is otherwise pornographic.
+        /// </summary>
         Explicit
     }
 }

--- a/BooruSharp/Search/Post/SearchResult.cs
+++ b/BooruSharp/Search/Post/SearchResult.cs
@@ -2,8 +2,29 @@
 
 namespace BooruSharp.Search.Post
 {
+    /// <summary>
+    /// Represents a post API search result.
+    /// </summary>
     public struct SearchResult
     {
+        /// <summary>
+        /// Initializes a <see cref="SearchResult"/> struct.
+        /// </summary>
+        /// <param name="fileUrl">The URI of the file.</param>
+        /// <param name="previewUrl">The URI of the preview image.</param>
+        /// <param name="postUrl">The URI of the post.</param>
+        /// <param name="rating">The post's rating.</param>
+        /// <param name="tags">The array containing all the tags associated with the file.</param>
+        /// <param name="id">The ID of the post.</param>
+        /// <param name="size">The size of the file, in bytes.</param>
+        /// <param name="height">The height of the image, in pixels.</param>
+        /// <param name="width">The width of the image, in pixels.</param>
+        /// <param name="previewHeight">The height of the preview image, in pixels.</param>
+        /// <param name="previewWidth">The width of the preview image, in pixels.</param>
+        /// <param name="creation">The creation date of the post.</param>
+        /// <param name="source">The original source of the file.</param>
+        /// <param name="score">The score of the post.</param>
+        /// <param name="md5">The MD5 hash of the file.</param>
         public SearchResult(Uri fileUrl, Uri previewUrl, Uri postUrl, Rating rating, string[] tags, int id,
                             int? size, int height, int width, int? previewHeight, int? previewWidth, DateTime? creation, string source, int? score, string md5)
         {
@@ -25,77 +46,83 @@ namespace BooruSharp.Search.Post
         }
 
         /// <summary>
-        /// Url of the image
+        /// Gets the URI of the file.
         /// </summary>
         public readonly Uri fileUrl;
 
         /// <summary>
-        /// Preview url of the image
+        /// Gets the URI of the preview image.
         /// </summary>
         public readonly Uri previewUrl;
 
         /// <summary>
-        /// The url of the post
+        /// Gets the URI of the post.
         /// </summary>
         public readonly Uri postUrl;
 
         /// <summary>
-        /// Is the image safe or not
+        /// Gets the post's rating.
         /// </summary>
         public readonly Rating rating;
 
         /// <summary>
-        /// All the tags contained in the image
+        /// Gets the array containing all the tags associated with the file.
         /// </summary>
         public readonly string[] tags;
 
         /// <summary>
-        /// Id of the image
+        /// Gets the ID of the post.
         /// </summary>
         public readonly int id;
 
         /// <summary>
-        /// Size in octets of the image
+        /// Gets the size of the file, in bytes, or
+        /// <see langword="null"/> if file size is unknown.
         /// </summary>
         public readonly int? size;
 
         /// <summary>
-        /// Height in pixels of the image
+        /// Gets the height of the image, in pixels.
         /// </summary>
         public readonly int height;
 
         /// <summary>
-        /// Width in pixels of the image
+        /// Gets the width of the image, in pixels.
         /// </summary>
         public readonly int width;
 
         /// <summary>
-        /// Height in pixels of the preview image
+        /// Gets the height of the preview image, in pixels,
+        /// or <see langword="null"/> if the height is unknown.
         /// </summary>
         public readonly int? previewHeight;
 
         /// <summary>
-        /// Width in pixels of the preview image
+        /// Gets the width of the preview image, in pixels,
+        /// or <see langword="null"/> if the width is unknown.
         /// </summary>
         public readonly int? previewWidth;
 
         /// <summary>
-        /// When was the post created
+        /// Gets the creation date of the post, or
+        /// <see langword="null"/> if the date is unknown.
         /// </summary>
         public readonly DateTime? creation;
 
         /// <summary>
-        /// Where the image is coming from
+        /// Gets the original source of the file.
         /// </summary>
         public readonly string source;
 
         /// <summary>
-        /// Score of the image
+        /// Gets the score of the post, or
+        /// <see langword="null"/> if the score is unknown.
         /// </summary>
         public readonly int? score;
 
         /// <summary>
-        /// Hash (md5) of the file
+        /// Gets the MD5 hash of the file, represented as
+        /// a sequence of 32 hexadecimal lowercase digits.
         /// </summary>
         public readonly string md5;
     }

--- a/BooruSharp/Search/Related/ABooru.cs
+++ b/BooruSharp/Search/Related/ABooru.cs
@@ -9,9 +9,13 @@ namespace BooruSharp.Booru
     public abstract partial class ABooru
     {
         /// <summary>
-        /// Get the tags related to another one
+        /// Gets the tags related to the specified <paramref name="tag"/>.
         /// </summary>
-        /// <param name="tag">The tag that the others must be related to</param>
+        /// <param name="tag">The tag that other tags must be related to.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentNullException"/>
+        /// <exception cref="Search.FeatureUnavailable"/>
+        /// <exception cref="System.Net.Http.HttpRequestException"/>
         public virtual async Task<Search.Related.SearchResult[]> GetRelatedAsync(string tag)
         {
             if (!HasRelatedAPI())

--- a/BooruSharp/Search/Related/SearchResult.cs
+++ b/BooruSharp/Search/Related/SearchResult.cs
@@ -1,7 +1,15 @@
 ﻿namespace BooruSharp.Search.Related
 {
+    /// <summary>
+    /// Represents a related API search result.
+    /// </summary>
     public struct SearchResult
     {
+        /// <summary>
+        /// Initializes a <see cref="SearchResult"/> struct.
+        /// </summary>
+        /// <param name="name">The name of the tag.</param>
+        /// <param name="count">The number of occurences of the tag.</param>
         public SearchResult(string name, int? count)
         {
             this.name = name;
@@ -9,12 +17,13 @@
         }
 
         /// <summary>
-        /// Name of the tag
+        /// Gets the name of the tag.
         /// </summary>
         public readonly string name;
 
         /// <summary>
-        /// Number of occurences of the tag
+        /// Gets the number of occurences of the tag, or
+        /// <see langword="null"/> if that number is unknown.
         /// </summary>
         public readonly int? count;
     }

--- a/BooruSharp/Search/Tag/ABooru.cs
+++ b/BooruSharp/Search/Tag/ABooru.cs
@@ -10,9 +10,14 @@ namespace BooruSharp.Booru
     public abstract partial class ABooru
     {
         /// <summary>
-        /// Get information about a tag
+        /// Gets information about a tag.
         /// </summary>
-        /// <param name="name">The name of the tag you want information about</param>
+        /// <param name="name">The name of the tag to get the information about.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentNullException"/>
+        /// <exception cref="Search.FeatureUnavailable"/>
+        /// <exception cref="System.Net.Http.HttpRequestException"/>
+        /// <exception cref="Search.InvalidTags"/>
         public virtual async Task<Search.Tag.SearchResult> GetTagAsync(string name)
         {
             if (!HasTagByIdAPI())
@@ -25,9 +30,13 @@ namespace BooruSharp.Booru
         }
 
         /// <summary>
-        /// Get information about a tag
+        /// Gets information about a tag.
         /// </summary>
-        /// <param name="name">The ID of the tag you want information about</param>
+        /// <param name="id">The ID of the tag to get the information about.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="Search.FeatureUnavailable"/>
+        /// <exception cref="System.Net.Http.HttpRequestException"/>
+        /// <exception cref="Search.InvalidTags"/>
         public virtual async Task<Search.Tag.SearchResult> GetTagAsync(int id)
         {
             if (!HasTagByIdAPI())
@@ -37,9 +46,13 @@ namespace BooruSharp.Booru
         }
 
         /// <summary>
-        /// Get the similar tags of the one given
+        /// Gets the tags similar to the tag specified by its <paramref name="name"/>.
         /// </summary>
-        /// <param name="name">The name of the tag you want others similar</param>
+        /// <param name="name">The name of the tag to find similar tags to.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentNullException"/>
+        /// <exception cref="Search.FeatureUnavailable"/>
+        /// <exception cref="System.Net.Http.HttpRequestException"/>
         public virtual async Task<Search.Tag.SearchResult[]> GetTagsAsync(string name)
         {
             if (!HasTagByIdAPI())

--- a/BooruSharp/Search/Tag/SearchResult.cs
+++ b/BooruSharp/Search/Tag/SearchResult.cs
@@ -1,7 +1,17 @@
 ﻿namespace BooruSharp.Search.Tag
 {
+    /// <summary>
+    /// Represents a tag API search result.
+    /// </summary>
     public struct SearchResult
     {
+        /// <summary>
+        /// Initializes a <see cref="SearchResult"/> struct.
+        /// </summary>
+        /// <param name="id">The ID of the tag.</param>
+        /// <param name="name">The name of the tag.</param>
+        /// <param name="type">The type of the tag.</param>
+        /// <param name="count">The number of occurences of the tag.</param>
         public SearchResult(int id, string name, TagType type, int count)
         {
             this.id = id;
@@ -11,22 +21,22 @@
         }
 
         /// <summary>
-        /// If of the tag
+        /// Gets the ID of the tag.
         /// </summary>
         public readonly int id;
 
         /// <summary>
-        /// Name of the tag
+        /// Gets the name of the tag.
         /// </summary>
         public readonly string name;
 
         /// <summary>
-        /// Type of the tag (character, copyright, etc...)
+        /// Gets the type of the tag.
         /// </summary>
         public readonly TagType type;
 
         /// <summary>
-        /// Number of occurences of the tag
+        /// Gets the number of occurences of the tag.
         /// </summary>
         public readonly int count;
     }

--- a/BooruSharp/Search/Tag/TagType.cs
+++ b/BooruSharp/Search/Tag/TagType.cs
@@ -1,11 +1,29 @@
 ﻿namespace BooruSharp.Search.Tag
 {
+    /// <summary>
+    /// Indicates the type of the tag.
+    /// </summary>
     public enum TagType
     {
+        /// <summary>
+        /// Indicates the common tag.
+        /// </summary>
         Trivia,
+        /// <summary>
+        /// Indicates the artist tag.
+        /// </summary>
         Artist,
+        /// <summary>
+        /// Indicates the copyright tag.
+        /// </summary>
         Copyright = 3,
+        /// <summary>
+        /// Indicates the character tag.
+        /// </summary>
         Character,
+        /// <summary>
+        /// Indicates the metadata tag.
+        /// </summary>
         Metadata
     }
 }

--- a/BooruSharp/Search/TooManyTags.cs
+++ b/BooruSharp/Search/TooManyTags.cs
@@ -1,7 +1,14 @@
 ﻿namespace BooruSharp.Search
 {
+    /// <summary>
+    /// Represents errors that occur whenever a method that requires a
+    /// tag query to perform an API request is supplied too many tags.
+    /// </summary>
     public class TooManyTags : System.ArgumentException
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TooManyTags"/> class.
+        /// </summary>
         public TooManyTags() : base("You can't have more than 2 tags for a search with this booru")
         { }
     }

--- a/BooruSharp/Search/Wiki/ABooru.cs
+++ b/BooruSharp/Search/Wiki/ABooru.cs
@@ -8,9 +8,14 @@ namespace BooruSharp.Booru
     public abstract partial class ABooru
     {
         /// <summary>
-        /// Get the wiki of a tag
+        /// Gets the wiki page of a tag.
         /// </summary>
-        /// <param name="query">The tag you want to get the wiki</param>
+        /// <param name="query">The tag to get the wiki page for.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentNullException"/>
+        /// <exception cref="Search.FeatureUnavailable"/>
+        /// <exception cref="System.Net.Http.HttpRequestException"/>
+        /// <exception cref="Search.InvalidTags"/>
         public virtual async Task<Search.Wiki.SearchResult> GetWikiAsync(string query)
         {
             if (!HasWikiAPI())

--- a/BooruSharp/Search/Wiki/SearchResult.cs
+++ b/BooruSharp/Search/Wiki/SearchResult.cs
@@ -2,8 +2,19 @@
 
 namespace BooruSharp.Search.Wiki
 {
+    /// <summary>
+    /// Represents a wiki entry API search result.
+    /// </summary>
     public struct SearchResult
     {
+        /// <summary>
+        /// Initializes a <see cref="SearchResult"/> struct.
+        /// </summary>
+        /// <param name="id">The ID of the wiki entry.</param>
+        /// <param name="title">The name of the described tag.</param>
+        /// <param name="creation">The date when the wiki entry was created.</param>
+        /// <param name="lastUpdate">The date of the latest update to the wiki entry.</param>
+        /// <param name="body">The tag description.</param>
         public SearchResult(int id, string title, DateTime creation, DateTime lastUpdate, string body)
         {
             this.id = id;
@@ -14,27 +25,27 @@ namespace BooruSharp.Search.Wiki
         }
 
         /// <summary>
-        /// Id of the wiki entry
+        /// Gets the ID of the wiki entry.
         /// </summary>
         public readonly int id;
 
         /// <summary>
-        /// Name of the tag described
+        /// Gets the name of the described tag.
         /// </summary>
         public readonly string title;
 
         /// <summary>
-        /// Date when the entry was created
+        /// Gets the date when the wiki entry was created.
         /// </summary>
         public readonly DateTime creation;
 
         /// <summary>
-        /// Date of the latest update to the entry
+        /// Gets the date of the latest update to the wiki entry.
         /// </summary>
         public readonly DateTime lastUpdate;
 
         /// <summary>
-        /// Tag description
+        /// Gets the tag description.
         /// </summary>
         public readonly string body;
     }


### PR DESCRIPTION
- Added XML documentation to every public member of `BooruSharp` and `BooruSharp.Others`
- Touched up existing documentation a bit
- Enabled XML documentation output, it will be automatically included with NuGet packages.

This PR is purely cosmetic, there's nothing changed about inner workings of the library, besides a few null checks added here and there for consistency. I've tried to stay close to the way Microsoft does their .NET documentation.

Please tell me if anything about this documentation should be corrected.

Previews of the new documentation in action:
![1](https://user-images.githubusercontent.com/57114830/91780622-b9d32880-ec00-11ea-8e7c-bf2b727c6d9d.png)
![2](https://user-images.githubusercontent.com/57114830/91780623-bb9cec00-ec00-11ea-9a33-3d6d0a55319e.png)
![3](https://user-images.githubusercontent.com/57114830/91780624-bcce1900-ec00-11ea-863d-4064a4970d21.png)
