### PR TITLE
Pixiv: correctly extract original image URL

### DIFF
--- a/BooruSharp.Others/Pixiv.cs
+++ b/BooruSharp.Others/Pixiv.cs
@@ -283,8 +283,16 @@ namespace BooruSharp.Others
                 tags.Remove("R-18");
             }
 
+            var originalImageUrlToken =
+                 // If there's multiple image URLs, get the first one.
+                 (post["meta_pages"]?.FirstOrDefault()?["image_urls"]?["original"])
+                 // If there's only one original image URL, use that one.
+                 ?? (post["meta_single_page"]?["original_image_url"])
+                 // Fallback to large image in case neither of the above succeeds.
+                 ?? (post["image_urls"]["large"]);
+
             return new SearchResult(
-                new Uri(post["image_urls"]["large"].Value<string>()),
+                new Uri(originalImageUrlToken.Value<string>()),
                 new Uri(post["image_urls"]["medium"].Value<string>()),
                 new Uri("https://www.pixiv.net/en/artworks/" + post["id"].Value<int>()),
                 isNsfw ? Rating.Explicit : Rating.Safe,

--- a/BooruSharp.Others/Pixiv.cs
+++ b/BooruSharp.Others/Pixiv.cs
@@ -84,7 +84,7 @@ namespace BooruSharp.Others
         public async Task<byte[]> PreviewToByteArrayAsync(SearchResult result)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, result.previewUrl);
-            request.Headers.Add("Referer", result.previewUrl.AbsoluteUri);
+            request.Headers.Add("Referer", result.postUrl.AbsoluteUri);
 
             var response = await HttpClient.SendAsync(request);
 


### PR DESCRIPTION
Pixiv responds with JSON that has original image URLs just fine, so let's use them. Makes `ImageToByteArrayAsync` method behave as expected.

Also set correct referer header in `PreviewToByteArrayAsync`'s request message.

Sample program I've used to check the correct behavior, downloads images from [this post](https://www.pixiv.net/en/artworks/84059414):
```csharp
using System;
using System.IO;
using System.Threading.Tasks;
using BooruSharp.Others;

namespace BooruSharpTests
{
    internal class Program
    {
        private static async Task Main(string[] args)
        {
            var pixiv = new Pixiv();

            Console.WriteLine("Logging in ...");
            await pixiv.LoginAsync("***", "***");

            Directory.CreateDirectory(@".\pixiv_test");

            var post = await pixiv.GetPostByIdAsync(84059414);
            await DownloadPost(pixiv, post);
        }

        private static async Task DownloadPost(Pixiv pixiv, BooruSharp.Search.Post.SearchResult post)
        {
            byte[] bytes;

            Console.WriteLine("Downloading image file ...");
            bytes = await pixiv.ImageToByteArrayAsync(post);
            Console.WriteLine("Writing image file ...");
            await File.WriteAllBytesAsync($@".\pixiv_test\{post.id}_orig.png", bytes);

            Console.WriteLine("Downloading preview file ...");
            bytes = await pixiv.PreviewToByteArrayAsync(post);
            Console.WriteLine("Writing preview file ...");
            await File.WriteAllBytesAsync($@".\pixiv_test\{post.id}_preview.png", bytes);
        }
    }
}
```

The original image from Pixiv site and the original image we've got from Pixiv API are identical, besides the fact that the latter is missing metadata.

| Image from Pixiv site | Downloaded original file | Downloaded preview file |
| --- | --- | --- |
| ![pixiv](https://user-images.githubusercontent.com/57114830/91900625-a202af80-eca7-11ea-8825-9d6e8bbc5543.png) | ![orig](https://user-images.githubusercontent.com/57114830/91900309-24d73a80-eca7-11ea-86c7-7482667a32c9.png) | ![preview](https://user-images.githubusercontent.com/57114830/91900321-2acd1b80-eca7-11ea-8033-2d112853c3bc.png) |