### PR TITLE
Code style improvements

### DIFF
--- a/BooruSharp.Others/Pixiv.cs
+++ b/BooruSharp.Others/Pixiv.cs
@@ -105,8 +105,8 @@ namespace BooruSharp.Others
         /// <exception cref="HttpRequestException"/>
         public async Task<byte[]> ImageToByteArrayAsync(SearchResult result)
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, result.fileUrl);
-            request.Headers.Add("Referer", result.postUrl.AbsoluteUri);
+            var request = new HttpRequestMessage(HttpMethod.Get, result.FileUrl);
+            request.Headers.Add("Referer", result.PostUrl.AbsoluteUri);
 
             var response = await HttpClient.SendAsync(request);
 
@@ -123,8 +123,8 @@ namespace BooruSharp.Others
         /// <exception cref="HttpRequestException"/>
         public async Task<byte[]> PreviewToByteArrayAsync(SearchResult result)
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, result.previewUrl);
-            request.Headers.Add("Referer", result.postUrl.AbsoluteUri);
+            var request = new HttpRequestMessage(HttpMethod.Get, result.PreviewUrl);
+            request.Headers.Add("Referer", result.PostUrl.AbsoluteUri);
 
             var response = await HttpClient.SendAsync(request);
 

--- a/BooruSharp.Others/Pixiv.cs
+++ b/BooruSharp.Others/Pixiv.cs
@@ -23,8 +23,8 @@ namespace BooruSharp.Others
         /// <summary>
         /// Initializes a new instance of the <see cref="Pixiv"/> class.
         /// </summary>
-        public Pixiv() : base("app-api.pixiv.net", (UrlFormat)(-1), BooruOptions.noComment | BooruOptions.noLastComments | BooruOptions.noMultipleRandom |
-                BooruOptions.noPostByMd5 | BooruOptions.noRelated | BooruOptions.noTagById | BooruOptions.noWiki | BooruOptions.noEmptyPostSearch)
+        public Pixiv() : base("app-api.pixiv.net", (UrlFormat)(-1), BooruOptions.NoComment | BooruOptions.NoLastComments | BooruOptions.NoMultipleRandom |
+                BooruOptions.NoPostByMD5 | BooruOptions.NoRelated | BooruOptions.NoTagByID | BooruOptions.NoWiki | BooruOptions.NoEmptyPostSearch)
         {
             AccessToken = null;
         }

--- a/BooruSharp.Others/Pixiv.cs
+++ b/BooruSharp.Others/Pixiv.cs
@@ -174,8 +174,7 @@ namespace BooruSharp.Others
         }
 
         /// <inheritdoc/>
-        public override bool IsSafe()
-            => false;
+        public override bool IsSafe => false;
 
         /// <summary>
         /// Adds a post with the specified ID to favorites.

--- a/BooruSharp.Others/Pixiv.cs
+++ b/BooruSharp.Others/Pixiv.cs
@@ -369,7 +369,7 @@ namespace BooruSharp.Others
                 new Uri(post["image_urls"]["medium"].Value<string>()),
                 new Uri("https://www.pixiv.net/en/artworks/" + post["id"].Value<int>()),
                 isNsfw ? Rating.Explicit : Rating.Safe,
-                tags.ToArray(),
+                tags,
                 post["id"].Value<int>(),
                 null,
                 post["height"].Value<int>(),

--- a/BooruSharp.Others/Pixiv.cs
+++ b/BooruSharp.Others/Pixiv.cs
@@ -23,8 +23,10 @@ namespace BooruSharp.Others
         /// <summary>
         /// Initializes a new instance of the <see cref="Pixiv"/> class.
         /// </summary>
-        public Pixiv() : base("app-api.pixiv.net", (UrlFormat)(-1), BooruOptions.NoComment | BooruOptions.NoLastComments | BooruOptions.NoMultipleRandom |
-                BooruOptions.NoPostByMD5 | BooruOptions.NoRelated | BooruOptions.NoTagByID | BooruOptions.NoWiki | BooruOptions.NoEmptyPostSearch)
+        public Pixiv()
+            : base("app-api.pixiv.net", UrlFormat.None, BooruOptions.NoComment | BooruOptions.NoLastComments
+                  | BooruOptions.NoMultipleRandom | BooruOptions.NoPostByMD5 | BooruOptions.NoRelated | BooruOptions.NoTagByID
+                  | BooruOptions.NoWiki | BooruOptions.NoEmptyPostSearch)
         {
             AccessToken = null;
         }
@@ -268,8 +270,9 @@ namespace BooruSharp.Others
                 throw new InvalidTags();
 
             int id = _random.Next(1, max + 1);
+            var requestUrl = _baseUrl + "/v1/search/illust?word=" + JoinTagsAndEscapeString(tagsArg) + "&offset=" + id;
 
-            var request = new HttpRequestMessage(HttpMethod.Get, _baseUrl + "/v1/search/illust?word=" + JoinTagsAndEscapeString(tagsArg) + "&offset=" + id);
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
             request.Headers.Add("Authorization", "Bearer " + AccessToken);
 
             var response = await HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
@@ -297,7 +300,9 @@ namespace BooruSharp.Others
 
             await CheckUpdateTokenAsync();
 
-            var request = new HttpRequestMessage(HttpMethod.Get, "https://www.pixiv.net/ajax/search/artworks/" + JoinTagsAndEscapeString(tagsArg));
+            var requestUrl = "https://www.pixiv.net/ajax/search/artworks/" + JoinTagsAndEscapeString(tagsArg);
+
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
 
             var response = await HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
 
@@ -321,7 +326,9 @@ namespace BooruSharp.Others
 
             await CheckUpdateTokenAsync();
 
-            var request = new HttpRequestMessage(HttpMethod.Get, _baseUrl + "/v1/search/illust?word=" + JoinTagsAndEscapeString(tagsArg));
+            string requestUrl = _baseUrl + "/v1/search/illust?word=" + JoinTagsAndEscapeString(tagsArg);
+
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
             request.Headers.Add("Authorization", "Bearer " + AccessToken);
 
             var response = await HttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);

--- a/BooruSharp.UnitTests/BooruTests.cs
+++ b/BooruSharp.UnitTests/BooruTests.cs
@@ -9,6 +9,8 @@ namespace BooruSharp.UnitTests
 {
     public class BooruTests
     {
+        private const int _randomPostCount = 5;
+
         [Fact]
         public void IsBooruAuthSet()
         {
@@ -107,7 +109,9 @@ namespace BooruSharp.UnitTests
                 if (!(booru is Pixiv))
                 {
                     string name = t.Name.ToUpperInvariant();
-                    booru.Auth = new BooruAuth(Environment.GetEnvironmentVariable(name + "_USER_ID"), Environment.GetEnvironmentVariable(name + "_PASSWORD_HASH"));
+                    booru.Auth = new BooruAuth(
+                        Environment.GetEnvironmentVariable(name + "_USER_ID"),
+                        Environment.GetEnvironmentVariable(name + "_PASSWORD_HASH"));
                 }
 
                 await Assert.ThrowsAsync<Search.InvalidPostId>(async () => await booru.AddFavoriteAsync(int.MaxValue));
@@ -145,7 +149,9 @@ namespace BooruSharp.UnitTests
                 if (!(booru is Pixiv))
                 {
                     string name = t.Name.ToUpperInvariant();
-                    booru.Auth = new BooruAuth(Environment.GetEnvironmentVariable(name + "_USER_ID"), Environment.GetEnvironmentVariable(name + "_PASSWORD_HASH"));
+                    booru.Auth = new BooruAuth(
+                        Environment.GetEnvironmentVariable(name + "_USER_ID"),
+                        Environment.GetEnvironmentVariable(name + "_PASSWORD_HASH"));
                 }
 
                 await booru.AddFavoriteAsync(id);
@@ -302,7 +308,10 @@ namespace BooruSharp.UnitTests
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetPostCountAsync());
             else
             {
-                int countEmpty = booru.NoEmptyPostSearch ? int.MaxValue : await booru.GetPostCountAsync(); // Pixiv doesn't handle PostCount with no tag
+                int countEmpty = booru.NoEmptyPostSearch
+                    ? int.MaxValue
+                    // Pixiv doesn't handle PostCount with no tag
+                    : await booru.GetPostCountAsync();
                 var countOne = await booru.GetPostCountAsync(tag);
                 var countTwo = await booru.GetPostCountAsync(tag, tag2);
                 Assert.NotEqual(0, countEmpty);
@@ -479,7 +488,8 @@ namespace BooruSharp.UnitTests
         [InlineData(typeof(Xbooru), false, "ocean", "small_breasts")]
         [InlineData(typeof(Yandere), false, "see_through", "loli", "swimsuits")]
         [InlineData(typeof(Pixiv), false, "東方", "貧乳", "水着")]
-        public async Task TooManyTags(Type t, bool throwError, string tag = "ocean", string tag2 = "flat_chest", string tag3 = "swimsuit")
+        public async Task TooManyTags(
+            Type t, bool throwError, string tag = "ocean", string tag2 = "flat_chest", string tag3 = "swimsuit")
         {
             var booru = await Boorus.GetAsync(t);
             Search.Post.SearchResult result;
@@ -516,7 +526,8 @@ namespace BooruSharp.UnitTests
         [InlineData(typeof(Xbooru), false, "ocean", "small_breasts")]
         [InlineData(typeof(Yandere), false, "see_through", "loli", "swimsuits")]
         [InlineData(typeof(Pixiv), false, "水", "貧乳", "水着")]
-        public async Task TooManyTagsMany(Type t, bool throwError, string tag = "ocean", string tag2 = "flat_chest", string tag3 = "swimsuit")
+        public async Task TooManyTagsMany(
+            Type t, bool throwError, string tag = "ocean", string tag2 = "flat_chest", string tag3 = "swimsuit")
         {
             var booru = await Boorus.GetAsync(t);
             Search.Post.SearchResult[] result;
@@ -524,14 +535,15 @@ namespace BooruSharp.UnitTests
             {
                 await Assert.ThrowsAsync<Search.TooManyTags>(async () =>
                 {
-                    result = await booru.GetRandomPostsAsync(5, tag, tag2, tag3);
+                    result = await booru.GetRandomPostsAsync(_randomPostCount, tag, tag2, tag3);
                 });
             }
             else if (!booru.HasMultipleRandomAPI)
-                await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetRandomPostsAsync(5, tag, tag2, tag3));
+                await Assert.ThrowsAsync<Search.FeatureUnavailable>(
+                    async () => await booru.GetRandomPostsAsync(_randomPostCount, tag, tag2, tag3));
             else
             {
-                result = await booru.GetRandomPostsAsync(5, tag, tag2, tag3);
+                result = await booru.GetRandomPostsAsync(_randomPostCount, tag, tag2, tag3);
                 foreach (var r in result)
                 {
                     Assert.Contains(tag, r.Tags);
@@ -560,7 +572,8 @@ namespace BooruSharp.UnitTests
         [InlineData(typeof(Pixiv))]
         public async Task GetRandomFail(Type t)
         {
-            await Assert.ThrowsAsync<Search.InvalidTags>(async () => await (await Boorus.GetAsync(t)).GetRandomPostAsync("someInvalidTag"));
+            await Assert.ThrowsAsync<Search.InvalidTags>(
+                async () => await (await Boorus.GetAsync(t)).GetRandomPostAsync("someInvalidTag"));
         }
 
         [SkippableTheory]
@@ -936,7 +949,8 @@ namespace BooruSharp.UnitTests
         /*[SkippableTheory]
         public async Task CheckNotAvailable(Type t)
         {
-            await Assert.ThrowsAsync<HttpRequestException>(async () => await ((Booru.Booru)Activator.CreateInstance(t, (BooruAuth)null)).CheckAvailability());
+            await Assert.ThrowsAsync<HttpRequestException>(
+                async () => await ((Booru.Booru)Activator.CreateInstance(t, (BooruAuth)null)).CheckAvailability());
         }*/
 
         [SkippableTheory]

--- a/BooruSharp.UnitTests/BooruTests.cs
+++ b/BooruSharp.UnitTests/BooruTests.cs
@@ -38,7 +38,7 @@ namespace BooruSharp.UnitTests
         public async Task UnsetFavoriteError(Type t)
         {
             var booru = await Boorus.GetAsync(t);
-            var id = (await General.GetRandomPost(booru)).id;
+            var id = (await General.GetRandomPost(booru)).ID;
             booru.Auth = new BooruAuth("AAA", "AAA");
             if (!booru.HasFavoriteAPI())
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.RemoveFavoriteAsync(id));
@@ -139,7 +139,7 @@ namespace BooruSharp.UnitTests
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.AddFavoriteAsync(10));
             else
             {
-                var id = (await General.GetRandomPost(booru)).id;
+                var id = (await General.GetRandomPost(booru)).ID;
 
                 // Pixiv doesn't support authorization using Auth property.
                 if (!(booru is Pixiv))
@@ -181,9 +181,9 @@ namespace BooruSharp.UnitTests
                 do
                 {
                     result1 = await General.GetRandomPost(booru);
-                } while (result1.md5 == null);
-                var result2 = await booru.GetPostByMd5Async(result1.md5);
-                Assert.Equal(result1.id, result2.id);
+                } while (result1.MD5 == null);
+                var result2 = await booru.GetPostByMd5Async(result1.MD5);
+                Assert.Equal(result1.ID, result2.ID);
             }
         }
 
@@ -212,8 +212,8 @@ namespace BooruSharp.UnitTests
             else
             {
                 Search.Post.SearchResult result1 = await General.GetRandomPost(booru);
-                var result2 = await booru.GetPostByIdAsync(result1.id);
-                Assert.Equal(result1.id, result2.id);
+                var result2 = await booru.GetPostByIdAsync(result1.ID);
+                Assert.Equal(result1.ID, result2.ID);
             }
         }
 
@@ -243,7 +243,7 @@ namespace BooruSharp.UnitTests
             {
                 var results = await booru.GetLastPostsAsync();
                 Assert.NotInRange(results.Length, 0, 1);
-                Assert.NotEqual(results[0].id, results[1].id);
+                Assert.NotEqual(results[0].ID, results[1].ID);
             }
         }
 
@@ -270,11 +270,11 @@ namespace BooruSharp.UnitTests
             Search.Post.SearchResult[] results;
             results = await booru.GetLastPostsAsync(tag, tag2);
             Assert.NotInRange(results.Length, 0, 1);
-            Assert.NotEqual(results[0].id, results[1].id);
+            Assert.NotEqual(results[0].ID, results[1].ID);
             foreach (var elem in results)
             {
-                Assert.Contains(elem.tags, t => t.Contains(tag));
-                Assert.Contains(elem.tags, t => t.Contains(tag2));
+                Assert.Contains(elem.Tags, t => t.Contains(tag));
+                Assert.Contains(elem.Tags, t => t.Contains(tag2));
             }
         }
 
@@ -387,7 +387,7 @@ namespace BooruSharp.UnitTests
                 var result = await booru.GetRandomPostsAsync(int.MaxValue, tag);
                 Assert.NotEmpty(result);
                 foreach (var r in result)
-                    Assert.Contains(r.tags, t => t.Contains(tag));
+                    Assert.Contains(r.Tags, t => t.Contains(tag));
             }
         }
 
@@ -424,8 +424,8 @@ namespace BooruSharp.UnitTests
         {
             var booru = await Boorus.GetAsync(t);
             var result = await booru.GetRandomPostAsync(tag, tag2);
-            Assert.Contains(result.tags, t => t.Contains(tag));
-            Assert.Contains(result.tags, t => t.Contains(tag2));
+            Assert.Contains(result.Tags, t => t.Contains(tag));
+            Assert.Contains(result.Tags, t => t.Contains(tag2));
         }
 
         [SkippableTheory]
@@ -456,8 +456,8 @@ namespace BooruSharp.UnitTests
                 Assert.NotEmpty(result);
                 foreach (var r in result)
                 {
-                    Assert.Contains(r.tags, t => t.Contains(tag));
-                    Assert.Contains(r.tags, t => t.Contains(tag2));
+                    Assert.Contains(r.Tags, t => t.Contains(tag));
+                    Assert.Contains(r.Tags, t => t.Contains(tag2));
                 }
             }
         }
@@ -493,9 +493,9 @@ namespace BooruSharp.UnitTests
             else
             {
                 result = await booru.GetRandomPostAsync(tag, tag2, tag3);
-                Assert.Contains(result.tags, x => x.Contains(tag));
-                Assert.Contains(result.tags, x => x.Contains(tag2));
-                Assert.Contains(result.tags, x => x.Contains(tag3));
+                Assert.Contains(result.Tags, x => x.Contains(tag));
+                Assert.Contains(result.Tags, x => x.Contains(tag2));
+                Assert.Contains(result.Tags, x => x.Contains(tag3));
             }
         }
 
@@ -534,9 +534,9 @@ namespace BooruSharp.UnitTests
                 result = await booru.GetRandomPostsAsync(5, tag, tag2, tag3);
                 foreach (var r in result)
                 {
-                    Assert.Contains(tag, r.tags);
-                    Assert.Contains(tag2, r.tags);
-                    Assert.Contains(tag3, r.tags);
+                    Assert.Contains(tag, r.Tags);
+                    Assert.Contains(tag2, r.Tags);
+                    Assert.Contains(tag3, r.Tags);
                 }
             }
         }
@@ -692,7 +692,7 @@ namespace BooruSharp.UnitTests
             if (!booru.HasTagByIdAPI())
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetTagAsync(tagId));
             else
-                Assert.Equal(tag, (await booru.GetTagAsync(tagId)).name);
+                Assert.Equal(tag, (await booru.GetTagAsync(tagId)).Name);
         }
 
         [SkippableTheory]
@@ -746,7 +746,7 @@ namespace BooruSharp.UnitTests
             else
             {
                 Search.Wiki.SearchResult result = await booru.GetWikiAsync(tag);
-                Assert.Equal(id, result.id);
+                Assert.Equal(id, result.ID);
                 General.CheckWiki(result);
             }
         }
@@ -803,7 +803,7 @@ namespace BooruSharp.UnitTests
             {
                 Search.Related.SearchResult[] result = await booru.GetRelatedAsync(tag);
                 General.CheckRelated(result);
-                Assert.Contains(result, x => x.name == related);
+                Assert.Contains(result, x => x.Name == related);
             }
         }
 
@@ -964,9 +964,9 @@ namespace BooruSharp.UnitTests
             for (int i = 0; i < 10; i++)
             {
                 var image = await b.GetRandomPostAsync(explicitTag);
-                if (isSafe && image.fileUrl != null)
-                    Assert.NotEqual(Search.Post.Rating.Explicit, image.rating);
-                if (image.rating == Search.Post.Rating.Explicit)
+                if (isSafe && image.FileUrl != null)
+                    Assert.NotEqual(Search.Post.Rating.Explicit, image.Rating);
+                if (image.Rating == Search.Post.Rating.Explicit)
                     foundExplicit = true;
             }
             if (!isSafe)

--- a/BooruSharp.UnitTests/BooruTests.cs
+++ b/BooruSharp.UnitTests/BooruTests.cs
@@ -40,7 +40,7 @@ namespace BooruSharp.UnitTests
             var booru = await Boorus.GetAsync(t);
             var id = (await General.GetRandomPost(booru)).ID;
             booru.Auth = new BooruAuth("AAA", "AAA");
-            if (!booru.HasFavoriteAPI())
+            if (!booru.HasFavoriteAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.RemoveFavoriteAsync(id));
             else if (t == typeof(Gelbooru))
                 await Assert.ThrowsAsync<Search.AuthentificationInvalid>(async () => await booru.RemoveFavoriteAsync(id));
@@ -71,7 +71,7 @@ namespace BooruSharp.UnitTests
             else
             {
                 booru.Auth = new BooruAuth("AAA", "AAA");
-                if (!booru.HasFavoriteAPI())
+                if (!booru.HasFavoriteAPI)
                     await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.AddFavoriteAsync(800));
                 else
                     await Assert.ThrowsAsync<Search.AuthentificationInvalid>(async () => await booru.AddFavoriteAsync(800));
@@ -99,7 +99,7 @@ namespace BooruSharp.UnitTests
         {
             var booru = await Boorus.GetAsync(t);
 
-            if (!booru.HasFavoriteAPI())
+            if (!booru.HasFavoriteAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.AddFavoriteAsync(int.MaxValue));
             else
             {
@@ -135,7 +135,7 @@ namespace BooruSharp.UnitTests
         {
             var booru = await Boorus.GetAsync(t);
 
-            if (!booru.HasFavoriteAPI())
+            if (!booru.HasFavoriteAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.AddFavoriteAsync(10));
             else
             {
@@ -173,7 +173,7 @@ namespace BooruSharp.UnitTests
         public async Task GetByMd5(Type t)
         {
             var booru = await Boorus.GetAsync(t);
-            if (!booru.HasPostByMd5API())
+            if (!booru.HasPostByMd5API)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetPostByMd5Async("0"));
             else
             {
@@ -207,7 +207,7 @@ namespace BooruSharp.UnitTests
         public async Task GetById(Type t)
         {
             var booru = await Boorus.GetAsync(t);
-            if (!booru.HasPostByIdAPI())
+            if (!booru.HasPostByIdAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetPostByIdAsync(0));
             else
             {
@@ -237,7 +237,7 @@ namespace BooruSharp.UnitTests
         public async Task GetLastPosts(Type t)
         {
             var booru = await Boorus.GetAsync(t);
-            if (booru.NoEmptyPostSearch())
+            if (booru.NoEmptyPostSearch)
                 await Assert.ThrowsAsync<ArgumentException>(async () => await booru.GetLastPostsAsync());
             else
             {
@@ -298,11 +298,11 @@ namespace BooruSharp.UnitTests
         public async Task GetPostCount(Type t, string tag = "hibiki_(kantai_collection)", string tag2 = "swimsuit")
         {
             var booru = await Boorus.GetAsync(t);
-            if (!booru.HasPostCountAPI())
+            if (!booru.HasPostCountAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetPostCountAsync());
             else
             {
-                int countEmpty = booru.NoEmptyPostSearch() ? int.MaxValue : await booru.GetPostCountAsync(); // Pixiv doesn't handle PostCount with no tag
+                int countEmpty = booru.NoEmptyPostSearch ? int.MaxValue : await booru.GetPostCountAsync(); // Pixiv doesn't handle PostCount with no tag
                 var countOne = await booru.GetPostCountAsync(tag);
                 var countTwo = await booru.GetPostCountAsync(tag, tag2);
                 Assert.NotEqual(0, countEmpty);
@@ -354,7 +354,7 @@ namespace BooruSharp.UnitTests
         public async Task GetRandoms(Type t, string tag = "school_swimsuit")
         {
             var booru = await Boorus.GetAsync(t);
-            if (!booru.HasMultipleRandomAPI())
+            if (!booru.HasMultipleRandomAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await General.CheckGetRandoms(booru, tag));
             else
                 await General.CheckGetRandoms(booru, tag);
@@ -380,7 +380,7 @@ namespace BooruSharp.UnitTests
         public async Task GetRandomsTooMany(Type t, string tag = "school_swimsuit")
         {
             var booru = await Boorus.GetAsync(t);
-            if (!booru.HasMultipleRandomAPI())
+            if (!booru.HasMultipleRandomAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetRandomPostsAsync(int.MaxValue, tag));
             else
             {
@@ -448,7 +448,7 @@ namespace BooruSharp.UnitTests
         public async Task GetRandoms2Tags(Type t, string tag = "hibiki_(kantai_collection)", string tag2 = "school_swimsuit")
         {
             var booru = await Boorus.GetAsync(t);
-            if (!booru.HasMultipleRandomAPI())
+            if (!booru.HasMultipleRandomAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetRandomPostsAsync(5, tag, tag2));
             else
             {
@@ -527,7 +527,7 @@ namespace BooruSharp.UnitTests
                     result = await booru.GetRandomPostsAsync(5, tag, tag2, tag3);
                 });
             }
-            else if (!booru.HasMultipleRandomAPI())
+            else if (!booru.HasMultipleRandomAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetRandomPostsAsync(5, tag, tag2, tag3));
             else
             {
@@ -583,7 +583,7 @@ namespace BooruSharp.UnitTests
         public async Task GetRandomsFail(Type t)
         {
             var booru = await Boorus.GetAsync(t);
-            if (!booru.HasMultipleRandomAPI())
+            if (!booru.HasMultipleRandomAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetRandomPostsAsync(5, "someInvalidTag"));
             else
                 Assert.Empty(await booru.GetRandomPostsAsync(5, "someInvalidTag"));
@@ -609,7 +609,7 @@ namespace BooruSharp.UnitTests
         public async Task CheckTag(Type t, string tag = "pantyhose")
         {
             var booru = await Boorus.GetAsync(t);
-            if (!booru.HasTagByIdAPI())
+            if (!booru.HasTagByIdAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetTagAsync(tag));
             else
                 await General.CheckTag(booru, tag);
@@ -635,7 +635,7 @@ namespace BooruSharp.UnitTests
         public async Task CheckTagFail(Type t)
         {
             var booru = await Boorus.GetAsync(t);
-            if (!booru.HasTagByIdAPI())
+            if (!booru.HasTagByIdAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetTagAsync("someRandomTag"));
             else
                 await Assert.ThrowsAsync<Search.InvalidTags>(() => booru.GetTagAsync("someRandomTag"));
@@ -661,7 +661,7 @@ namespace BooruSharp.UnitTests
         public async Task CheckTags(Type t, string tag, bool onlyOnce)
         {
             var booru = await Boorus.GetAsync(t);
-            if (!booru.HasTagByIdAPI())
+            if (!booru.HasTagByIdAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetTagAsync(tag));
             else if (onlyOnce)
                 Assert.NotEmpty(await booru.GetTagsAsync(tag));
@@ -689,7 +689,7 @@ namespace BooruSharp.UnitTests
         public async Task TagId(Type t, string tag, int tagId)
         {
             var booru = await Boorus.GetAsync(t);
-            if (!booru.HasTagByIdAPI())
+            if (!booru.HasTagByIdAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetTagAsync(tagId));
             else
                 Assert.Equal(tag, (await booru.GetTagAsync(tagId)).Name);
@@ -715,7 +715,7 @@ namespace BooruSharp.UnitTests
         public async Task TagIdFail(Type t)
         {
             var booru = await Boorus.GetAsync(t);
-            if (!booru.HasTagByIdAPI())
+            if (!booru.HasTagByIdAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetTagAsync(int.MaxValue));
             else
                 await Assert.ThrowsAsync<Search.InvalidTags>(() => booru.GetTagAsync(int.MaxValue));
@@ -741,7 +741,7 @@ namespace BooruSharp.UnitTests
         public async Task CheckWiki(Type t, string tag, int? id)
         {
             var booru = await Boorus.GetAsync(t);
-            if (!booru.HasWikiAPI())
+            if (!booru.HasWikiAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetWikiAsync(tag));
             else
             {
@@ -771,7 +771,7 @@ namespace BooruSharp.UnitTests
         public async Task CheckWikiFail(Type t)
         {
             var booru = await Boorus.GetAsync(t);
-            if (!booru.HasWikiAPI())
+            if (!booru.HasWikiAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetWikiAsync("yetAnotherTag"));
             else
                 await Assert.ThrowsAsync<Search.InvalidTags>(() => booru.GetWikiAsync("yetAnotherTag"));
@@ -797,7 +797,7 @@ namespace BooruSharp.UnitTests
         public async Task CheckRelated(Type t, string tag, string related)
         {
             var booru = await Boorus.GetAsync(t);
-            if (!booru.HasRelatedAPI())
+            if (!booru.HasRelatedAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetRelatedAsync(tag));
             else
             {
@@ -827,7 +827,7 @@ namespace BooruSharp.UnitTests
         public async Task CheckRelatedFail(Type t)
         {
             var booru = await Boorus.GetAsync(t);
-            if (!booru.HasRelatedAPI())
+            if (!booru.HasRelatedAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetRelatedAsync("thisWillFail"));
             else
                 Assert.Empty(await booru.GetRelatedAsync("thisWillFail"));
@@ -853,7 +853,7 @@ namespace BooruSharp.UnitTests
         public async Task CheckComment(Type t, int id)
         {
             var booru = await Boorus.GetAsync(t);
-            if (!booru.HasCommentAPI())
+            if (!booru.HasCommentAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetCommentsAsync(id));
             else
                 General.CheckComment(await booru.GetCommentsAsync(id));
@@ -879,7 +879,7 @@ namespace BooruSharp.UnitTests
         public async Task CheckCommentFail(Type t)
         {
             var booru = await Boorus.GetAsync(t);
-            if (!booru.HasCommentAPI())
+            if (!booru.HasCommentAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetCommentsAsync(int.MaxValue));
             else
                 Assert.Empty(await booru.GetCommentsAsync(int.MaxValue));
@@ -905,7 +905,7 @@ namespace BooruSharp.UnitTests
         public async Task CheckLastComment(Type t)
         {
             var booru = await Boorus.GetAsync(t);
-            if (!booru.HasSearchLastComment())
+            if (!booru.HasSearchLastComment)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(async () => await booru.GetLastCommentsAsync());
             else
                 General.CheckComment(await booru.GetLastCommentsAsync());
@@ -959,7 +959,7 @@ namespace BooruSharp.UnitTests
         public async Task CheckIsSafe(Type t, string explicitTag = "pussy")
         {
             ABooru b = await Boorus.GetAsync(t);
-            bool isSafe = b.IsSafe();
+            bool isSafe = b.IsSafe;
             bool foundExplicit = false;
             for (int i = 0; i < 10; i++)
             {

--- a/BooruSharp.UnitTests/General.cs
+++ b/BooruSharp.UnitTests/General.cs
@@ -22,33 +22,33 @@ namespace BooruSharp.UnitTests
             }
             catch (WebException ex)
             { 
-                return ex.Message + " for " + url;
+                return ex.Message + " for " + url; 
             }
         }
 
         public static async Task CheckResult(Search.Post.SearchResult result, string inputTag)
         {
-            if (result.fileUrl != null)
+            if (result.FileUrl != null)
             {
-                string resFile = await CheckUrl(result.fileUrl);
-                string resPreview = await CheckUrl(result.previewUrl);
-                string resPost = await CheckUrl(result.postUrl);
+                string resFile = await CheckUrl(result.FileUrl);
+                string resPreview = await CheckUrl(result.PreviewUrl);
+                string resPost = await CheckUrl(result.PostUrl);
                 Assert.True(resPost == null, resPost);
                 Assert.True(resFile == null, resFile);
                 Assert.True(resPreview == null, resPreview);
-                Assert.NotEqual(0, result.height);
-                Assert.NotEqual(0, result.width);
-                if (result.previewHeight != null)
+                Assert.NotEqual(0, result.Height);
+                Assert.NotEqual(0, result.Width);
+                if (result.PreviewHeight != null)
                 {
-                    Assert.NotEqual(0, result.previewHeight);
-                    Assert.NotEqual(0, result.previewWidth);
+                    Assert.NotEqual(0, result.PreviewHeight);
+                    Assert.NotEqual(0, result.PreviewWidth);
                 }
             }
-            Assert.InRange(result.rating, Search.Post.Rating.Safe, Search.Post.Rating.Explicit);
-            Assert.Contains(result.tags, t => t.Contains(inputTag));
-            Assert.NotEqual(0, result.id);
-            if (result.size.HasValue)
-                Assert.NotEqual(0, result.size.Value);
+            Assert.InRange(result.Rating, Search.Post.Rating.Safe, Search.Post.Rating.Explicit);
+            Assert.Contains(result.Tags, t => t.Contains(inputTag));
+            Assert.NotEqual(0, result.ID);
+            if (result.Size.HasValue)
+                Assert.NotEqual(0, result.Size.Value);
         }
 
         public static async Task CheckGetRandom(ABooru booru, string s1)
@@ -60,8 +60,8 @@ namespace BooruSharp.UnitTests
             {
                 result2 = await booru.GetRandomPostAsync(s1);
                 i++;
-            } while (result.id == result2.id && i < 5);
-            Assert.NotEqual(result.id, result2.id);
+            } while (result.ID == result2.ID && i < 5);
+            Assert.NotEqual(result.ID, result2.ID);
             await CheckResult(result, s1);
         }
 
@@ -76,23 +76,23 @@ namespace BooruSharp.UnitTests
                 result2 = await booru.GetRandomPostsAsync(5, s1);
                 Assert.NotEmpty(result2);
                 i++;
-            } while (result[0].id == result2[0].id && i < 5);
-            Assert.NotEqual(result[0].id, result2[0].id);
+            } while (result[0].ID == result2[0].ID && i < 5);
+            Assert.NotEqual(result[0].ID, result2[0].ID);
             await CheckResult(result[0], s1);
         }
 
         public static async Task CheckTag(ABooru booru, string s1 = "pantyhose")
         {
             Search.Tag.SearchResult result = await booru.GetTagAsync(s1);
-            Assert.Equal(s1, result.name);
-            Assert.InRange(result.type, Search.Tag.TagType.Trivia, Search.Tag.TagType.Metadata);
-            Assert.NotEqual((Search.Tag.TagType)2, result.type);
-            Assert.NotEqual(0, result.count);
+            Assert.Equal(s1, result.Name);
+            Assert.InRange(result.Type, Search.Tag.TagType.Trivia, Search.Tag.TagType.Metadata);
+            Assert.NotEqual((Search.Tag.TagType)2, result.Type);
+            Assert.NotEqual(0, result.Count);
         }
 
         public static void CheckWiki(Search.Wiki.SearchResult result)
         {
-            Assert.InRange(result.lastUpdate, result.creation, DateTime.Now);
+            Assert.InRange(result.LastUpdate, result.Creation, DateTime.Now);
         }
 
         public static void CheckRelated(Search.Related.SearchResult[] result)
@@ -104,10 +104,10 @@ namespace BooruSharp.UnitTests
         {
             foreach (Search.Comment.SearchResult res in result)
             {
-                Assert.NotEqual(0, res.authorId);
-                Assert.NotEqual(0, res.commentId);
-                Assert.NotEqual(0, res.postId);
-                Assert.NotEmpty(res.body);
+                Assert.NotEqual(0, res.AuthorID);
+                Assert.NotEqual(0, res.CommentID);
+                Assert.NotEqual(0, res.PostID);
+                Assert.NotEmpty(res.Body);
             }
             Assert.NotEmpty(result);
         }
@@ -117,7 +117,7 @@ namespace BooruSharp.UnitTests
             if (res1.Length != res2.Length)
                 return false;
             for (int i = 0; i < res1.Length; i++)
-                if (res1[i].id != res2[i].id)
+                if (res1[i].ID != res2[i].ID)
                     return false;
             return true;
         }

--- a/BooruSharp.UnitTests/General.cs
+++ b/BooruSharp.UnitTests/General.cs
@@ -9,6 +9,10 @@ namespace BooruSharp.UnitTests
 {
     public static class General
     {
+        private const int _randomPostIterationCount = 5;
+        private const int _randomPostCount = 5;
+        private const Search.Tag.TagType _unknownTagType = (Search.Tag.TagType)2;
+
         private static async Task<string> CheckUrl(Uri url)
         {
             try
@@ -21,7 +25,7 @@ namespace BooruSharp.UnitTests
                 return null;
             }
             catch (WebException ex)
-            { 
+            {
                 return ex.Message + " for " + url;
             }
         }
@@ -60,23 +64,23 @@ namespace BooruSharp.UnitTests
             {
                 result2 = await booru.GetRandomPostAsync(s1);
                 i++;
-            } while (result.ID == result2.ID && i < 5);
+            } while (result.ID == result2.ID && i < _randomPostIterationCount);
             Assert.NotEqual(result.ID, result2.ID);
             await CheckResult(result, s1);
         }
 
         public static async Task CheckGetRandoms(ABooru booru, string s1)
         {
-            Search.Post.SearchResult[] result = await booru.GetRandomPostsAsync(5, s1);
+            Search.Post.SearchResult[] result = await booru.GetRandomPostsAsync(_randomPostCount, s1);
             Assert.NotEmpty(result);
             Search.Post.SearchResult[] result2;
             int i = 0;
             do
             {
-                result2 = await booru.GetRandomPostsAsync(5, s1);
+                result2 = await booru.GetRandomPostsAsync(_randomPostCount, s1);
                 Assert.NotEmpty(result2);
                 i++;
-            } while (result[0].ID == result2[0].ID && i < 5);
+            } while (result[0].ID == result2[0].ID && i < _randomPostIterationCount);
             Assert.NotEqual(result[0].ID, result2[0].ID);
             await CheckResult(result[0], s1);
         }
@@ -86,7 +90,7 @@ namespace BooruSharp.UnitTests
             Search.Tag.SearchResult result = await booru.GetTagAsync(s1);
             Assert.Equal(s1, result.Name);
             Assert.InRange(result.Type, Search.Tag.TagType.Trivia, Search.Tag.TagType.Metadata);
-            Assert.NotEqual((Search.Tag.TagType)2, result.Type);
+            Assert.NotEqual(_unknownTagType, result.Type);
             Assert.NotEqual(0, result.Count);
         }
 

--- a/BooruSharp.UnitTests/General.cs
+++ b/BooruSharp.UnitTests/General.cs
@@ -22,7 +22,7 @@ namespace BooruSharp.UnitTests
             }
             catch (WebException ex)
             { 
-                return ex.Message + " for " + url; 
+                return ex.Message + " for " + url;
             }
         }
 
@@ -124,7 +124,7 @@ namespace BooruSharp.UnitTests
 
         public static async Task<Search.Post.SearchResult> GetRandomPost(ABooru booru)
         {
-            if (booru.NoEmptyPostSearch())
+            if (booru.NoEmptyPostSearch)
                 return await booru.GetRandomPostAsync("スク水"); // Pixiv doesn't handle random search with no tag
             return await booru.GetRandomPostAsync();
         }

--- a/BooruSharp.UnitTests/OtherTests.cs
+++ b/BooruSharp.UnitTests/OtherTests.cs
@@ -11,31 +11,41 @@ namespace BooruSharp.UnitTests
         [Fact]
         public async Task GelbooruTagCharacter()
         {
-            Assert.Equal(Search.Tag.TagType.Character, (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("cirno")).Type);
+            Assert.Equal(
+                Search.Tag.TagType.Character,
+                (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("cirno")).Type);
         }
 
         [Fact]
         public async Task GelbooruTagCopyright()
         {
-            Assert.Equal(Search.Tag.TagType.Copyright, (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("kantai_collection")).Type);
+            Assert.Equal(
+                Search.Tag.TagType.Copyright,
+                (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("kantai_collection")).Type);
         }
 
         [Fact]
         public async Task GelbooruTagArtist()
         {
-            Assert.Equal(Search.Tag.TagType.Artist, (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("mtu_(orewamuzituda)")).Type);
+            Assert.Equal(
+                Search.Tag.TagType.Artist,
+                (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("mtu_(orewamuzituda)")).Type);
         }
 
         [Fact]
         public async Task GelbooruTagMetadata()
         {
-            Assert.Equal(Search.Tag.TagType.Metadata, (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("uncensored")).Type);
+            Assert.Equal(
+                Search.Tag.TagType.Metadata,
+                (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("uncensored")).Type);
         }
 
         [Fact]
         public async Task GelbooruTagTrivia()
         {
-            Assert.Equal(Search.Tag.TagType.Trivia, (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("futanari")).Type);
+            Assert.Equal(
+                Search.Tag.TagType.Trivia,
+                (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("futanari")).Type);
         }
     }
 }

--- a/BooruSharp.UnitTests/OtherTests.cs
+++ b/BooruSharp.UnitTests/OtherTests.cs
@@ -11,31 +11,31 @@ namespace BooruSharp.UnitTests
         [Fact]
         public async Task GelbooruTagCharacter()
         {
-            Assert.Equal(Search.Tag.TagType.Character, (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("cirno")).type);
+            Assert.Equal(Search.Tag.TagType.Character, (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("cirno")).Type);
         }
 
         [Fact]
         public async Task GelbooruTagCopyright()
         {
-            Assert.Equal(Search.Tag.TagType.Copyright, (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("kantai_collection")).type);
+            Assert.Equal(Search.Tag.TagType.Copyright, (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("kantai_collection")).Type);
         }
 
         [Fact]
         public async Task GelbooruTagArtist()
         {
-            Assert.Equal(Search.Tag.TagType.Artist, (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("mtu_(orewamuzituda)")).type);
+            Assert.Equal(Search.Tag.TagType.Artist, (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("mtu_(orewamuzituda)")).Type);
         }
 
         [Fact]
         public async Task GelbooruTagMetadata()
         {
-            Assert.Equal(Search.Tag.TagType.Metadata, (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("uncensored")).type);
+            Assert.Equal(Search.Tag.TagType.Metadata, (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("uncensored")).Type);
         }
 
         [Fact]
         public async Task GelbooruTagTrivia()
         {
-            Assert.Equal(Search.Tag.TagType.Trivia, (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("futanari")).type);
+            Assert.Equal(Search.Tag.TagType.Trivia, (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("futanari")).Type);
         }
     }
 }

--- a/BooruSharp/Booru/ABooru.cs
+++ b/BooruSharp/Booru/ABooru.cs
@@ -19,7 +19,7 @@ namespace BooruSharp.Booru
         /// Gets whether this booru is considered safe (that is, all posts on
         /// this booru have rating of <see cref="Search.Post.Rating.Safe"/>).
         /// </summary>
-        public abstract bool IsSafe();
+        public abstract bool IsSafe { get; }
 
         private protected virtual Search.Comment.SearchResult GetCommentSearchResult(object json)
             => throw new FeatureUnavailable();
@@ -42,89 +42,86 @@ namespace BooruSharp.Booru
         private protected virtual Search.Wiki.SearchResult GetWikiSearchResult(object json)
             => throw new FeatureUnavailable();
 
-        // TODO: these flag checking methods need to be turned into properties at some point,
-        // using properties for these kind of checks expresses the intent behind them more clearly.
-
         /// <summary>
         /// Gets whether it is possible to search for related tags on this booru.
         /// </summary>
-        public bool HasRelatedAPI() => !_options.HasFlag(BooruOptions.NoRelated);
+        public bool HasRelatedAPI => !_options.HasFlag(BooruOptions.NoRelated);
 
         /// <summary>
         /// Gets whether it is possible to search for wiki entries on this booru.
         /// </summary>
-        public bool HasWikiAPI() => !_options.HasFlag(BooruOptions.NoWiki);
+        public bool HasWikiAPI => !_options.HasFlag(BooruOptions.NoWiki);
 
         /// <summary>
         /// Gets whether it is possible to search for comments on this booru.
         /// </summary>
-        public bool HasCommentAPI() => !_options.HasFlag(BooruOptions.NoComment);
+        public bool HasCommentAPI => !_options.HasFlag(BooruOptions.NoComment);
 
         /// <summary>
         /// Gets whether it is possible to search for tags by their IDs on this booru.
         /// </summary>
-        public bool HasTagByIdAPI() => !_options.HasFlag(BooruOptions.NoTagByID);
+        public bool HasTagByIdAPI => !_options.HasFlag(BooruOptions.NoTagByID);
 
         /// <summary>
         /// Gets whether it is possible to search for the last comments on this booru.
         /// </summary>
-            // As a failsafe also check for the availability of comment API.
-        public bool HasSearchLastComment() => HasCommentAPI() && !_options.HasFlag(BooruOptions.NoLastComments);
+        // As a failsafe also check for the availability of comment API.
+        public bool HasSearchLastComment => HasCommentAPI && !_options.HasFlag(BooruOptions.NoLastComments);
 
         /// <summary>
         /// Gets whether it is possible to search for posts by their MD5 on this booru.
         /// </summary>
-        public bool HasPostByMd5API() => !_options.HasFlag(BooruOptions.NoPostByMD5);
+        public bool HasPostByMd5API => !_options.HasFlag(BooruOptions.NoPostByMD5);
 
         /// <summary>
         /// Gets whether it is possible to search for posts by their ID on this booru.
         /// </summary>
-        public bool HasPostByIdAPI() => !_options.HasFlag(BooruOptions.NoPostByID);
+        public bool HasPostByIdAPI => !_options.HasFlag(BooruOptions.NoPostByID);
 
         /// <summary>
         /// Gets whether it is possible to get the total number of posts on this booru.
         /// </summary>
-        public bool HasPostCountAPI() => !_options.HasFlag(BooruOptions.NoPostCount);
+        public bool HasPostCountAPI => !_options.HasFlag(BooruOptions.NoPostCount);
 
         /// <summary>
         /// Gets whether it is possible to get multiple random images on this booru.
         /// </summary>
-        public bool HasMultipleRandomAPI() => !_options.HasFlag(BooruOptions.NoMultipleRandom);
+        public bool HasMultipleRandomAPI => !_options.HasFlag(BooruOptions.NoMultipleRandom);
 
         /// <summary>
         /// Gets whether this booru supports adding or removing favorite posts.
         /// </summary>
-        public bool HasFavoriteAPI() => !_options.HasFlag(BooruOptions.NoFavorite);
+        public bool HasFavoriteAPI => !_options.HasFlag(BooruOptions.NoFavorite);
 
         /// <summary>
         /// Gets whether this booru can't call post functions without search arguments.
         /// </summary>
-        public bool NoEmptyPostSearch() => _options.HasFlag(BooruOptions.NoEmptyPostSearch);
+        public bool NoEmptyPostSearch => _options.HasFlag(BooruOptions.NoEmptyPostSearch);
 
         /// <summary>
         /// Gets a value indicating whether http:// scheme is used instead of https://.
         /// </summary>
-        protected bool UsesHttp() => _options.HasFlag(BooruOptions.UseHttp);
+        protected bool UsesHttp => _options.HasFlag(BooruOptions.UseHttp);
 
         /// <summary>
         /// Gets a value indicating whether tags API uses XML instead of JSON.
         /// </summary>
-        protected bool TagsUseXml() => _options.HasFlag(BooruOptions.TagApiXml);
+        protected bool TagsUseXml => _options.HasFlag(BooruOptions.TagApiXml);
 
         /// <summary>
         /// Gets a value indicating whether comments API uses XML instead of JSON.
         /// </summary>
-        protected bool CommentsUseXml() => _options.HasFlag(BooruOptions.CommentApiXml);
+        protected bool CommentsUseXml => _options.HasFlag(BooruOptions.CommentApiXml);
 
         /// <summary>
         /// Gets a value indicating whether searching by more than two tags at once is not allowed.
         /// </summary>
-        protected bool NoMoreThanTwoTags() => _options.HasFlag(BooruOptions.NoMoreThan2Tags);
+        protected bool NoMoreThanTwoTags => _options.HasFlag(BooruOptions.NoMoreThan2Tags);
 
         /// <summary>
         /// Gets a value indicating whether the max limit of posts per search is increased (used by Gelbooru).
         /// </summary>
-        protected bool SearchIncreasedPostLimit() => _options.HasFlag(BooruOptions.LimitOf20000);
+        protected bool SearchIncreasedPostLimit => _options.HasFlag(BooruOptions.LimitOf20000);
 
         /// <summary>
         /// Checks for the booru availability.
@@ -158,7 +155,7 @@ namespace BooruSharp.Booru
             HttpClient = null;
             _options = options;
 
-            bool useHttp = UsesHttp(); // Cache returned value for faster access.
+            bool useHttp = UsesHttp; // Cache returned value for faster access.
 #pragma warning disable CS0618 // Keep this field for a while in case someone still depends on it.
             _useHttp = useHttp;
 #pragma warning restore CS0618
@@ -173,17 +170,17 @@ namespace BooruSharp.Booru
 
             _tagUrl = "http" + (useHttp ? "" : "s") + "://" + baseUrl + "/" + GetUrl(format, "tag");
 
-            if (HasWikiAPI())
+            if (HasWikiAPI)
                 _wikiUrl = format == UrlFormat.Danbooru
                     ? "http" + (useHttp ? "" : "s") + "://" + baseUrl + "/" + GetUrl(format, "wiki_page")
                     : "http" + (useHttp ? "" : "s") + "://" + baseUrl + "/" + GetUrl(format, "wiki");
 
-            if (HasRelatedAPI())
+            if (HasRelatedAPI)
                 _relatedUrl = format == UrlFormat.Danbooru
                     ? "http" + (useHttp ? "" : "s") + "://" + baseUrl + "/" + GetUrl(format, "related_tag")
                     : "http" + (useHttp ? "" : "s") + "://" + baseUrl + "/" + GetUrl(format, "tag", "related");
 
-            if (HasCommentAPI())
+            if (HasCommentAPI)
                 _commentUrl = "http" + (useHttp ? "" : "s") + "://" + baseUrl + "/" + GetUrl(format, "comment");
         }
 

--- a/BooruSharp/Booru/ABooru.cs
+++ b/BooruSharp/Booru/ABooru.cs
@@ -153,6 +153,8 @@ namespace BooruSharp.Booru
                 _imageUrlXml = _imageUrl.Replace("json=1", "json=0");
             else if (_format == UrlFormat.PostIndexJson)
                 _imageUrlXml = _imageUrl.Replace("index.json", "index.xml");
+            else
+                _imageUrlXml = null;
 
             _tagUrl = "http" + (useHttp ? "" : "s") + "://" + baseUrl + "/" + GetUrl(format, "tag");
 

--- a/BooruSharp/Booru/ABooru.cs
+++ b/BooruSharp/Booru/ABooru.cs
@@ -137,17 +137,6 @@ namespace BooruSharp.Booru
         /// </summary>
         /// <param name="baseUrl">The base URL to use. This should be a host name.</param>
         /// <param name="format">The URL format to use.</param>
-        /// <param name="options">The collection of option values.</param>
-        [Obsolete(_deprecationMessage)]
-        protected ABooru(string baseUrl, UrlFormat format, params BooruOptions[] options)
-            : this(baseUrl, format, MergeOptions(options))
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ABooru"/> class.
-        /// </summary>
-        /// <param name="baseUrl">The base URL to use. This should be a host name.</param>
-        /// <param name="format">The URL format to use.</param>
         /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
         protected ABooru(string baseUrl, UrlFormat format, BooruOptions options)
         {
@@ -156,9 +145,6 @@ namespace BooruSharp.Booru
             _options = options;
 
             bool useHttp = UsesHttp; // Cache returned value for faster access.
-#pragma warning disable CS0618 // Keep this field for a while in case someone still depends on it.
-            _useHttp = useHttp;
-#pragma warning restore CS0618
             _baseUrl = "http" + (useHttp ? "" : "s") + "://" + baseUrl;
             _format = format;
             _imageUrl = "http" + (useHttp ? "" : "s") + "://" + baseUrl + "/" + GetUrl(format, "post");
@@ -256,32 +242,6 @@ namespace BooruSharp.Booru
                 : value + "=";
         }
 
-        [Obsolete]
-        // TODO: remove this method after removing obsolete constructors.
-        private protected static BooruOptions[] CombineArrays(BooruOptions[] arr1, BooruOptions[] arr2)
-        {
-            var arr = new BooruOptions[arr1.Length + arr2.Length];
-            arr1.CopyTo(arr, 0);
-            arr2.CopyTo(arr, arr1.Length);
-            return arr;
-        }
-
-        /// <summary>
-        /// Method for compatibility with old API. Combines multiple options
-        /// into singular <see cref="BooruOptions"/> object.
-        /// </summary>
-        // TODO: remove this method after removing obsolete constructors.
-        [Obsolete("This method will be removed in the future version of the API.")]
-        protected static BooruOptions MergeOptions(BooruOptions[] array)
-        {
-            BooruOptions options = BooruOptions.None;
-
-            for (int i = 0; i < array.Length; i++)
-                options |= array[i];
-
-            return options;
-        }
-
         /// <summary>
         /// Gets or sets authentication credentials.
         /// </summary>
@@ -316,16 +276,9 @@ namespace BooruSharp.Booru
         /// </summary>
         protected static readonly Random _random = new Random();
         /// <summary>
-        /// Contains a value indicating whether http:// scheme is used instead of https://.
-        /// </summary>
-        [Obsolete("UsesHttp method should be used instead.")]
-        protected readonly bool _useHttp; // Use http instead of https
-        /// <summary>
         /// Contains the base request URL of this booru.
         /// </summary>
         protected readonly string _baseUrl;
-        // TODO: remove this message after removing obsolete constructors.
-        private protected const string _deprecationMessage = "Use a contructor that accepts single BooruOptions parameter. Use | (bitwise OR) operator to combine multiple options.";
         private HttpClient _client;
         private readonly string _imageUrlXml, _imageUrl, _tagUrl, _wikiUrl, _relatedUrl, _commentUrl; // URLs for differents endpoints
         // All options are stored in a bit field and can be retrieved using related methods/properties.

--- a/BooruSharp/Booru/ABooru.cs
+++ b/BooruSharp/Booru/ABooru.cs
@@ -48,83 +48,83 @@ namespace BooruSharp.Booru
         /// <summary>
         /// Gets whether it is possible to search for related tags on this booru.
         /// </summary>
-        public bool HasRelatedAPI() => !_options.HasFlag(BooruOptions.noRelated);
+        public bool HasRelatedAPI() => !_options.HasFlag(BooruOptions.NoRelated);
 
         /// <summary>
         /// Gets whether it is possible to search for wiki entries on this booru.
         /// </summary>
-        public bool HasWikiAPI() => !_options.HasFlag(BooruOptions.noWiki);
+        public bool HasWikiAPI() => !_options.HasFlag(BooruOptions.NoWiki);
 
         /// <summary>
         /// Gets whether it is possible to search for comments on this booru.
         /// </summary>
-        public bool HasCommentAPI() => !_options.HasFlag(BooruOptions.noComment);
+        public bool HasCommentAPI() => !_options.HasFlag(BooruOptions.NoComment);
 
         /// <summary>
         /// Gets whether it is possible to search for tags by their IDs on this booru.
         /// </summary>
-        public bool HasTagByIdAPI() => !_options.HasFlag(BooruOptions.noTagById);
+        public bool HasTagByIdAPI() => !_options.HasFlag(BooruOptions.NoTagByID);
 
         /// <summary>
         /// Gets whether it is possible to search for the last comments on this booru.
         /// </summary>
             // As a failsafe also check for the availability of comment API.
-        public bool HasSearchLastComment() => HasCommentAPI() && !_options.HasFlag(BooruOptions.noLastComments);
+        public bool HasSearchLastComment() => HasCommentAPI() && !_options.HasFlag(BooruOptions.NoLastComments);
 
         /// <summary>
         /// Gets whether it is possible to search for posts by their MD5 on this booru.
         /// </summary>
-        public bool HasPostByMd5API() => !_options.HasFlag(BooruOptions.noPostByMd5);
+        public bool HasPostByMd5API() => !_options.HasFlag(BooruOptions.NoPostByMD5);
 
         /// <summary>
         /// Gets whether it is possible to search for posts by their ID on this booru.
         /// </summary>
-        public bool HasPostByIdAPI() => !_options.HasFlag(BooruOptions.noPostById);
+        public bool HasPostByIdAPI() => !_options.HasFlag(BooruOptions.NoPostByID);
 
         /// <summary>
         /// Gets whether it is possible to get the total number of posts on this booru.
         /// </summary>
-        public bool HasPostCountAPI() => !_options.HasFlag(BooruOptions.noPostCount);
+        public bool HasPostCountAPI() => !_options.HasFlag(BooruOptions.NoPostCount);
 
         /// <summary>
         /// Gets whether it is possible to get multiple random images on this booru.
         /// </summary>
-        public bool HasMultipleRandomAPI() => !_options.HasFlag(BooruOptions.noMultipleRandom);
+        public bool HasMultipleRandomAPI() => !_options.HasFlag(BooruOptions.NoMultipleRandom);
 
         /// <summary>
         /// Gets whether this booru supports adding or removing favorite posts.
         /// </summary>
-        public bool HasFavoriteAPI() => !_options.HasFlag(BooruOptions.noFavorite);
+        public bool HasFavoriteAPI() => !_options.HasFlag(BooruOptions.NoFavorite);
 
         /// <summary>
         /// Gets whether this booru can't call post functions without search arguments.
         /// </summary>
-        public bool NoEmptyPostSearch() => _options.HasFlag(BooruOptions.noEmptyPostSearch);
+        public bool NoEmptyPostSearch() => _options.HasFlag(BooruOptions.NoEmptyPostSearch);
 
         /// <summary>
         /// Gets a value indicating whether http:// scheme is used instead of https://.
         /// </summary>
-        protected bool UsesHttp() => _options.HasFlag(BooruOptions.useHttp);
+        protected bool UsesHttp() => _options.HasFlag(BooruOptions.UseHttp);
 
         /// <summary>
         /// Gets a value indicating whether tags API uses XML instead of JSON.
         /// </summary>
-        protected bool TagsUseXml() => _options.HasFlag(BooruOptions.tagApiXml);
+        protected bool TagsUseXml() => _options.HasFlag(BooruOptions.TagApiXml);
 
         /// <summary>
         /// Gets a value indicating whether comments API uses XML instead of JSON.
         /// </summary>
-        protected bool CommentsUseXml() => _options.HasFlag(BooruOptions.commentApiXml);
+        protected bool CommentsUseXml() => _options.HasFlag(BooruOptions.CommentApiXml);
 
         /// <summary>
         /// Gets a value indicating whether searching by more than two tags at once is not allowed.
         /// </summary>
-        protected bool NoMoreThanTwoTags() => _options.HasFlag(BooruOptions.noMoreThan2Tags);
+        protected bool NoMoreThanTwoTags() => _options.HasFlag(BooruOptions.NoMoreThan2Tags);
 
         /// <summary>
         /// Gets a value indicating whether the max limit of posts per search is increased (used by Gelbooru).
         /// </summary>
-        protected bool SearchIncreasedPostLimit() => _options.HasFlag(BooruOptions.limitOf20000);
+        protected bool SearchIncreasedPostLimit() => _options.HasFlag(BooruOptions.LimitOf20000);
 
         /// <summary>
         /// Checks for the booru availability.
@@ -166,20 +166,20 @@ namespace BooruSharp.Booru
             _format = format;
             _imageUrl = "http" + (useHttp ? "" : "s") + "://" + baseUrl + "/" + GetUrl(format, "post");
 
-            if (_format == UrlFormat.indexPhp)
+            if (_format == UrlFormat.IndexPhp)
                 _imageUrlXml = _imageUrl.Replace("json=1", "json=0");
-            else if (_format == UrlFormat.postIndexJson)
+            else if (_format == UrlFormat.PostIndexJson)
                 _imageUrlXml = _imageUrl.Replace("index.json", "index.xml");
 
             _tagUrl = "http" + (useHttp ? "" : "s") + "://" + baseUrl + "/" + GetUrl(format, "tag");
 
             if (HasWikiAPI())
-                _wikiUrl = format == UrlFormat.danbooru
+                _wikiUrl = format == UrlFormat.Danbooru
                     ? "http" + (useHttp ? "" : "s") + "://" + baseUrl + "/" + GetUrl(format, "wiki_page")
                     : "http" + (useHttp ? "" : "s") + "://" + baseUrl + "/" + GetUrl(format, "wiki");
 
             if (HasRelatedAPI())
-                _relatedUrl = format == UrlFormat.danbooru
+                _relatedUrl = format == UrlFormat.Danbooru
                     ? "http" + (useHttp ? "" : "s") + "://" + baseUrl + "/" + GetUrl(format, "related_tag")
                     : "http" + (useHttp ? "" : "s") + "://" + baseUrl + "/" + GetUrl(format, "tag", "related");
 
@@ -191,16 +191,16 @@ namespace BooruSharp.Booru
         {
             switch (format)
             {
-                case UrlFormat.postIndexJson:
+                case UrlFormat.PostIndexJson:
                     return query + "/" + squery + ".json";
 
-                case UrlFormat.indexPhp:
+                case UrlFormat.IndexPhp:
                     return "index.php?page=dapi&s=" + query + "&q=index&json=1";
 
-                case UrlFormat.danbooru:
+                case UrlFormat.Danbooru:
                     return query == "related_tag" ? query + ".json" : query + "s.json";
 
-                case UrlFormat.sankaku:
+                case UrlFormat.Sankaku:
                     return query == "wiki" ? query : query + "s";
 
                 default:
@@ -240,7 +240,7 @@ namespace BooruSharp.Booru
 
         private string CreateUrl(string url, params string[] args)
         {
-            return _format == UrlFormat.indexPhp
+            return _format == UrlFormat.IndexPhp
                 ? url + "&" + string.Join("&", args)
                 : url + "?" + string.Join("&", args);
         }
@@ -254,7 +254,7 @@ namespace BooruSharp.Booru
 
         private string SearchArg(string value)
         {
-            return _format == UrlFormat.danbooru
+            return _format == UrlFormat.Danbooru
                 ? "search[" + value + "]="
                 : value + "=";
         }
@@ -277,7 +277,7 @@ namespace BooruSharp.Booru
         [Obsolete("This method will be removed in the future version of the API.")]
         protected static BooruOptions MergeOptions(BooruOptions[] array)
         {
-            BooruOptions options = BooruOptions.none;
+            BooruOptions options = BooruOptions.None;
 
             for (int i = 0; i < array.Length; i++)
                 options |= array[i];

--- a/BooruSharp/Booru/Atfbooru.cs
+++ b/BooruSharp/Booru/Atfbooru.cs
@@ -13,6 +13,6 @@
         { }
 
         /// <inheritdoc/>
-        public override bool IsSafe() => false;
+        public override bool IsSafe => false;
     }
 }

--- a/BooruSharp/Booru/Atfbooru.cs
+++ b/BooruSharp/Booru/Atfbooru.cs
@@ -9,7 +9,8 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Atfbooru"/> class.
         /// </summary>
-        public Atfbooru() : base("booru.allthefallen.moe")
+        public Atfbooru()
+            : base("booru.allthefallen.moe")
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/BooruOptions.cs
+++ b/BooruSharp/Booru/BooruOptions.cs
@@ -13,70 +13,70 @@ namespace BooruSharp.Booru
         /// <summary>
         /// Indicates that no additional options should be used when creating an <see cref="ABooru"/> object.
         /// </summary>
-        none = 0,
+        None = 0,
         /// <summary>
         /// Indicates that http:// URI scheme should be used instead of https:// URI scheme.
         /// </summary>
-        useHttp = 1 << 0,
+        UseHttp = 1 << 0,
         /// <summary>
         /// Indicates that wiki API is not available.
         /// </summary>
-        noWiki = 1 << 1,
+        NoWiki = 1 << 1,
         /// <summary>
         /// Indicates that related post API is not available.
         /// </summary>
-        noRelated = 1 << 2,
+        NoRelated = 1 << 2,
         /// <summary>
         /// Indicates that comments API is not available.
         /// </summary>
-        noComment = 1 << 3,
+        NoComment = 1 << 3,
         /// <summary>
         /// Indicates that searching for tags by ID is not available.
         /// </summary>
-        noTagById = 1 << 4,
+        NoTagByID = 1 << 4,
         /// <summary>
         /// Indicates that searching for posts by MD5 hash is not available.
         /// </summary>
-        noPostByMd5 = 1 << 5,
+        NoPostByMD5 = 1 << 5,
         /// <summary>
         /// Indicates that searching for posts by ID is not available.
         /// </summary>
-        noPostById = 1 << 6,
+        NoPostByID = 1 << 6,
         /// <summary>
         /// Indicates that latest comments API is not available.
         /// </summary>
-        noLastComments = 1 << 7,
+        NoLastComments = 1 << 7,
         /// <summary>
         /// Indicates that total post count API is not available.
         /// </summary>
-        noPostCount = 1 << 8,
+        NoPostCount = 1 << 8,
         /// <summary>
         /// Indicates that retrieving multiple random posts API is not available.
         /// </summary>
-        noMultipleRandom = 1 << 9,
+        NoMultipleRandom = 1 << 9,
         /// <summary>
         /// Indicates that favoriting API is not available.
         /// </summary>
-        noFavorite = 1 << 10,
+        NoFavorite = 1 << 10,
         /// <summary>
         /// Indicates that comments API respond with XML instead of JSON.
         /// </summary>
-        commentApiXml = 1 << 11,
+        CommentApiXml = 1 << 11,
         /// <summary>
         /// Indicates that tags API respond with XML instead of JSON.
         /// </summary>
-        tagApiXml = 1 << 12,
+        TagApiXml = 1 << 12,
         /// <summary>
         /// Indicates that maximum limit of posts per search is increased.
         /// </summary>
-        limitOf20000 = 1 << 13,
+        LimitOf20000 = 1 << 13,
         /// <summary>
         /// Indicates that at most 2 tags can be used for post searching.
         /// </summary>
-        noMoreThan2Tags = 1 << 14,
+        NoMoreThan2Tags = 1 << 14,
         /// <summary>
         /// Indicates that search parameter must be provided in order for post search functions to work.
         /// </summary>
-        noEmptyPostSearch = 1 << 15,
+        NoEmptyPostSearch = 1 << 15,
     }
 }

--- a/BooruSharp/Booru/DanbooruDonmai.cs
+++ b/BooruSharp/Booru/DanbooruDonmai.cs
@@ -9,7 +9,7 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="DanbooruDonmai"/> class.
         /// </summary>
-        public DanbooruDonmai() : base("danbooru.donmai.us", BooruOptions.noMoreThan2Tags)
+        public DanbooruDonmai() : base("danbooru.donmai.us", BooruOptions.NoMoreThan2Tags)
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/DanbooruDonmai.cs
+++ b/BooruSharp/Booru/DanbooruDonmai.cs
@@ -9,7 +9,8 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="DanbooruDonmai"/> class.
         /// </summary>
-        public DanbooruDonmai() : base("danbooru.donmai.us", BooruOptions.NoMoreThan2Tags)
+        public DanbooruDonmai()
+            : base("danbooru.donmai.us", BooruOptions.NoMoreThan2Tags)
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/DanbooruDonmai.cs
+++ b/BooruSharp/Booru/DanbooruDonmai.cs
@@ -13,6 +13,6 @@
         { }
 
         /// <inheritdoc/>
-        public override bool IsSafe() => false;
+        public override bool IsSafe => false;
     }
 }

--- a/BooruSharp/Booru/E621.cs
+++ b/BooruSharp/Booru/E621.cs
@@ -13,6 +13,6 @@
         { }
 
         /// <inheritdoc/>
-        public override bool IsSafe() => false;
+        public override bool IsSafe => false;
     }
 }

--- a/BooruSharp/Booru/E621.cs
+++ b/BooruSharp/Booru/E621.cs
@@ -9,7 +9,8 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="E621"/> class.
         /// </summary>
-        public E621() : base("e621.net")
+        public E621()
+            : base("e621.net")
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/E926.cs
+++ b/BooruSharp/Booru/E926.cs
@@ -17,6 +17,6 @@
         /// <see cref="E926"/> can provide images with an explicit rating,
         /// but the URL of the file will be <see langword="null"/>.
         /// </remarks>
-        public override bool IsSafe() => true;
+        public override bool IsSafe => true;
     }
 }

--- a/BooruSharp/Booru/E926.cs
+++ b/BooruSharp/Booru/E926.cs
@@ -9,7 +9,8 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="E926"/> class.
         /// </summary>
-        public E926() : base("e926.net")
+        public E926()
+            : base("e926.net")
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/Furrybooru.cs
+++ b/BooruSharp/Booru/Furrybooru.cs
@@ -9,7 +9,8 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Furrybooru"/> class.
         /// </summary>
-        public Furrybooru() : base("furry.booru.org", BooruOptions.UseHttp)
+        public Furrybooru()
+            : base("furry.booru.org", BooruOptions.UseHttp)
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/Furrybooru.cs
+++ b/BooruSharp/Booru/Furrybooru.cs
@@ -9,7 +9,7 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Furrybooru"/> class.
         /// </summary>
-        public Furrybooru() : base("furry.booru.org", BooruOptions.useHttp)
+        public Furrybooru() : base("furry.booru.org", BooruOptions.UseHttp)
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/Furrybooru.cs
+++ b/BooruSharp/Booru/Furrybooru.cs
@@ -13,6 +13,6 @@
         { }
 
         /// <inheritdoc/>
-        public override bool IsSafe() => false;
+        public override bool IsSafe => false;
     }
 }

--- a/BooruSharp/Booru/Gelbooru.cs
+++ b/BooruSharp/Booru/Gelbooru.cs
@@ -13,6 +13,6 @@
         { }
 
         /// <inheritdoc/>
-        public override bool IsSafe() => false;
+        public override bool IsSafe => false;
     }
 }

--- a/BooruSharp/Booru/Gelbooru.cs
+++ b/BooruSharp/Booru/Gelbooru.cs
@@ -9,7 +9,8 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Gelbooru"/> class.
         /// </summary>
-        public Gelbooru() : base("gelbooru.com")
+        public Gelbooru()
+            : base("gelbooru.com")
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/Konachan.cs
+++ b/BooruSharp/Booru/Konachan.cs
@@ -13,6 +13,6 @@
         { }
 
         /// <inheritdoc/>
-        public override bool IsSafe() => false;
+        public override bool IsSafe => false;
     }
 }

--- a/BooruSharp/Booru/Konachan.cs
+++ b/BooruSharp/Booru/Konachan.cs
@@ -9,7 +9,8 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Konachan"/> class.
         /// </summary>
-        public Konachan() : base("konachan.com")
+        public Konachan()
+            : base("konachan.com")
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/Lolibooru.cs
+++ b/BooruSharp/Booru/Lolibooru.cs
@@ -15,7 +15,7 @@ namespace BooruSharp.Booru
         { }
 
         /// <inheritdoc/>
-        public override bool IsSafe() => false;
+        public override bool IsSafe => false;
 
         private protected override Search.Tag.SearchResult GetTagSearchResult(object json)
         {

--- a/BooruSharp/Booru/Lolibooru.cs
+++ b/BooruSharp/Booru/Lolibooru.cs
@@ -11,7 +11,8 @@ namespace BooruSharp.Booru
         /// <summary>
         /// Initializes a new instance of the <see cref="Lolibooru"/> class.
         /// </summary>
-        public Lolibooru() : base("lolibooru.moe")
+        public Lolibooru()
+            : base("lolibooru.moe")
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/Realbooru.cs
+++ b/BooruSharp/Booru/Realbooru.cs
@@ -13,6 +13,6 @@
         { }
 
         /// <inheritdoc/>
-        public override bool IsSafe() => false;
+        public override bool IsSafe => false;
     }
 }

--- a/BooruSharp/Booru/Realbooru.cs
+++ b/BooruSharp/Booru/Realbooru.cs
@@ -9,7 +9,8 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Realbooru"/> class.
         /// </summary>
-        public Realbooru() : base("realbooru.com")
+        public Realbooru()
+            : base("realbooru.com")
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/Rule34.cs
+++ b/BooruSharp/Booru/Rule34.cs
@@ -9,7 +9,7 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Rule34"/> class.
         /// </summary>
-        public Rule34() : base("rule34.xxx", BooruOptions.noComment | BooruOptions.limitOf20000) // The limit is in fact 200000 but search with tags make it incredibly hard to know what is really your pid
+        public Rule34() : base("rule34.xxx", BooruOptions.NoComment | BooruOptions.LimitOf20000) // The limit is in fact 200000 but search with tags make it incredibly hard to know what is really your pid
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/Rule34.cs
+++ b/BooruSharp/Booru/Rule34.cs
@@ -13,6 +13,6 @@
         { }
 
         /// <inheritdoc/>
-        public override bool IsSafe() => false;
+        public override bool IsSafe => false;
     }
 }

--- a/BooruSharp/Booru/Rule34.cs
+++ b/BooruSharp/Booru/Rule34.cs
@@ -9,7 +9,9 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Rule34"/> class.
         /// </summary>
-        public Rule34() : base("rule34.xxx", BooruOptions.NoComment | BooruOptions.LimitOf20000) // The limit is in fact 200000 but search with tags make it incredibly hard to know what is really your pid
+        public Rule34()
+            // The limit is in fact 200000 but search with tags make it incredibly hard to know what is really your pid
+            : base("rule34.xxx", BooruOptions.NoComment | BooruOptions.LimitOf20000)
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/Safebooru.cs
+++ b/BooruSharp/Booru/Safebooru.cs
@@ -9,7 +9,8 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Safebooru"/> class.
         /// </summary>
-        public Safebooru() : base("safebooru.org", BooruOptions.NoComment)
+        public Safebooru()
+            : base("safebooru.org", BooruOptions.NoComment)
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/Safebooru.cs
+++ b/BooruSharp/Booru/Safebooru.cs
@@ -9,7 +9,7 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Safebooru"/> class.
         /// </summary>
-        public Safebooru() : base("safebooru.org", BooruOptions.noComment)
+        public Safebooru() : base("safebooru.org", BooruOptions.NoComment)
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/Safebooru.cs
+++ b/BooruSharp/Booru/Safebooru.cs
@@ -13,6 +13,6 @@
         { }
 
         /// <inheritdoc/>
-        public override bool IsSafe() => true;
+        public override bool IsSafe => true;
     }
 }

--- a/BooruSharp/Booru/Sakugabooru.cs
+++ b/BooruSharp/Booru/Sakugabooru.cs
@@ -9,7 +9,7 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Sakugabooru"/> class.
         /// </summary>
-        public Sakugabooru() : base("sakugabooru.com", BooruOptions.noLastComments)
+        public Sakugabooru() : base("sakugabooru.com", BooruOptions.NoLastComments)
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/Sakugabooru.cs
+++ b/BooruSharp/Booru/Sakugabooru.cs
@@ -9,7 +9,8 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Sakugabooru"/> class.
         /// </summary>
-        public Sakugabooru() : base("sakugabooru.com", BooruOptions.NoLastComments)
+        public Sakugabooru()
+            : base("sakugabooru.com", BooruOptions.NoLastComments)
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/Sakugabooru.cs
+++ b/BooruSharp/Booru/Sakugabooru.cs
@@ -13,6 +13,6 @@
         { }
 
         /// <inheritdoc/>
-        public override bool IsSafe() => false;
+        public override bool IsSafe => false;
     }
 }

--- a/BooruSharp/Booru/SankakuComplex.cs
+++ b/BooruSharp/Booru/SankakuComplex.cs
@@ -9,7 +9,8 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="SankakuComplex"/> class.
         /// </summary>
-        public SankakuComplex() : base("capi-v2.sankakucomplex.com")
+        public SankakuComplex()
+            : base("capi-v2.sankakucomplex.com")
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/SankakuComplex.cs
+++ b/BooruSharp/Booru/SankakuComplex.cs
@@ -13,6 +13,6 @@
         { }
 
         /// <inheritdoc/>
-        public override bool IsSafe() => false;
+        public override bool IsSafe => false;
     }
 }

--- a/BooruSharp/Booru/Template/Danbooru.cs
+++ b/BooruSharp/Booru/Template/Danbooru.cs
@@ -13,15 +13,6 @@ namespace BooruSharp.Booru.Template
         /// Initializes a new instance of the <see cref="Danbooru"/> template class.
         /// </summary>
         /// <param name="url">The base URL to use. This should be a host name.</param>
-        /// <param name="options">The collection of option values.</param>
-        [Obsolete(_deprecationMessage)]
-        public Danbooru(string url, params BooruOptions[] options) : this(url, MergeOptions(options))
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Danbooru"/> template class.
-        /// </summary>
-        /// <param name="url">The base URL to use. This should be a host name.</param>
         /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
         public Danbooru(string url, BooruOptions options = BooruOptions.None) : base(url, UrlFormat.Danbooru, options | BooruOptions.NoLastComments | BooruOptions.NoPostCount | BooruOptions.NoFavorite)
         { }

--- a/BooruSharp/Booru/Template/Danbooru.cs
+++ b/BooruSharp/Booru/Template/Danbooru.cs
@@ -23,7 +23,7 @@ namespace BooruSharp.Booru.Template
         /// </summary>
         /// <param name="url">The base URL to use. This should be a host name.</param>
         /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
-        public Danbooru(string url, BooruOptions options = BooruOptions.none) : base(url, UrlFormat.danbooru, options | BooruOptions.noLastComments | BooruOptions.noPostCount | BooruOptions.noFavorite)
+        public Danbooru(string url, BooruOptions options = BooruOptions.None) : base(url, UrlFormat.Danbooru, options | BooruOptions.NoLastComments | BooruOptions.NoPostCount | BooruOptions.NoFavorite)
         { }
 
         private protected override JToken ParseFirstPostSearchResult(object json)

--- a/BooruSharp/Booru/Template/Danbooru.cs
+++ b/BooruSharp/Booru/Template/Danbooru.cs
@@ -14,7 +14,9 @@ namespace BooruSharp.Booru.Template
         /// </summary>
         /// <param name="url">The base URL to use. This should be a host name.</param>
         /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
-        public Danbooru(string url, BooruOptions options = BooruOptions.None) : base(url, UrlFormat.Danbooru, options | BooruOptions.NoLastComments | BooruOptions.NoPostCount | BooruOptions.NoFavorite)
+        protected Danbooru(string url, BooruOptions options = BooruOptions.None)
+            : base(url, UrlFormat.Danbooru, options | BooruOptions.NoLastComments | BooruOptions.NoPostCount
+                  | BooruOptions.NoFavorite)
         { }
 
         private protected override JToken ParseFirstPostSearchResult(object json)

--- a/BooruSharp/Booru/Template/E621.cs
+++ b/BooruSharp/Booru/Template/E621.cs
@@ -13,15 +13,6 @@ namespace BooruSharp.Booru.Template
         /// Initializes a new instance of the <see cref="E621"/> template class.
         /// </summary>
         /// <param name="url">The base URL to use. This should be a host name.</param>
-        /// <param name="options">The collection of option values.</param>
-        [Obsolete(_deprecationMessage)]
-        public E621(string url, params BooruOptions[] options) : this(url, MergeOptions(options))
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="E621"/> template class.
-        /// </summary>
-        /// <param name="url">The base URL to use. This should be a host name.</param>
         /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
         public E621(string url, BooruOptions options = BooruOptions.None) : base(url, UrlFormat.Danbooru, options | BooruOptions.NoWiki | BooruOptions.NoRelated | BooruOptions.NoComment | BooruOptions.NoTagByID | BooruOptions.NoPostByID | BooruOptions.NoPostCount | BooruOptions.NoFavorite)
         { }

--- a/BooruSharp/Booru/Template/E621.cs
+++ b/BooruSharp/Booru/Template/E621.cs
@@ -23,7 +23,7 @@ namespace BooruSharp.Booru.Template
         /// </summary>
         /// <param name="url">The base URL to use. This should be a host name.</param>
         /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
-        public E621(string url, BooruOptions options = BooruOptions.none) : base(url, UrlFormat.danbooru, options | BooruOptions.noWiki | BooruOptions.noRelated | BooruOptions.noComment | BooruOptions.noTagById | BooruOptions.noPostById | BooruOptions.noPostCount | BooruOptions.noFavorite)
+        public E621(string url, BooruOptions options = BooruOptions.None) : base(url, UrlFormat.Danbooru, options | BooruOptions.NoWiki | BooruOptions.NoRelated | BooruOptions.NoComment | BooruOptions.NoTagByID | BooruOptions.NoPostByID | BooruOptions.NoPostCount | BooruOptions.NoFavorite)
         { }
 
         private protected override JToken ParseFirstPostSearchResult(object json)

--- a/BooruSharp/Booru/Template/E621.cs
+++ b/BooruSharp/Booru/Template/E621.cs
@@ -14,7 +14,9 @@ namespace BooruSharp.Booru.Template
         /// </summary>
         /// <param name="url">The base URL to use. This should be a host name.</param>
         /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
-        public E621(string url, BooruOptions options = BooruOptions.None) : base(url, UrlFormat.Danbooru, options | BooruOptions.NoWiki | BooruOptions.NoRelated | BooruOptions.NoComment | BooruOptions.NoTagByID | BooruOptions.NoPostByID | BooruOptions.NoPostCount | BooruOptions.NoFavorite)
+        protected E621(string url, BooruOptions options = BooruOptions.None)
+            : base(url, UrlFormat.Danbooru, options | BooruOptions.NoWiki | BooruOptions.NoRelated | BooruOptions.NoComment 
+                  | BooruOptions.NoTagByID | BooruOptions.NoPostByID | BooruOptions.NoPostCount | BooruOptions.NoFavorite)
         { }
 
         private protected override JToken ParseFirstPostSearchResult(object json)

--- a/BooruSharp/Booru/Template/Gelbooru.cs
+++ b/BooruSharp/Booru/Template/Gelbooru.cs
@@ -19,8 +19,9 @@ namespace BooruSharp.Booru.Template
         /// </summary>
         /// <param name="url">The base URL to use. This should be a host name.</param>
         /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
-        public Gelbooru(string url, BooruOptions options = BooruOptions.None) : base(url, UrlFormat.IndexPhp, options |
-             BooruOptions.NoWiki | BooruOptions.NoRelated | BooruOptions.LimitOf20000 | BooruOptions.CommentApiXml)
+        protected Gelbooru(string url, BooruOptions options = BooruOptions.None)
+            : base(url, UrlFormat.IndexPhp, options | BooruOptions.NoWiki | BooruOptions.NoRelated | BooruOptions.LimitOf20000
+                  | BooruOptions.CommentApiXml)
         { }
 
         /// <inheritdoc/>
@@ -59,9 +60,12 @@ namespace BooruSharp.Booru.Template
         {
             const string gelbooruTimeFormat = "ddd MMM dd HH:mm:ss zzz yyyy";
 
+            string directory = elem["directory"].Value<string>();
+            string image = elem["image"].Value<string>();
+
             return new Search.Post.SearchResult(
                 new Uri(elem["file_url"].Value<string>()),
-                new Uri("https://gelbooru.com/thumbnails/" + elem["directory"].Value<string>() + "/thumbnail_" + elem["image"].Value<string>()),
+                new Uri("https://gelbooru.com/thumbnails/" + directory + "/thumbnail_" + image),
                 new Uri(_baseUrl + "/index.php?page=post&s=view&id=" + elem["id"].Value<int>()),
                 GetRating(elem["rating"].Value<string>()[0]),
                 elem["tags"].Value<string>().Split(' '),

--- a/BooruSharp/Booru/Template/Gelbooru.cs
+++ b/BooruSharp/Booru/Template/Gelbooru.cs
@@ -28,8 +28,8 @@ namespace BooruSharp.Booru.Template
         /// </summary>
         /// <param name="url">The base URL to use. This should be a host name.</param>
         /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
-        public Gelbooru(string url, BooruOptions options = BooruOptions.none) : base(url, UrlFormat.indexPhp, options |
-             BooruOptions.noWiki | BooruOptions.noRelated | BooruOptions.limitOf20000 | BooruOptions.commentApiXml)
+        public Gelbooru(string url, BooruOptions options = BooruOptions.None) : base(url, UrlFormat.IndexPhp, options |
+             BooruOptions.NoWiki | BooruOptions.NoRelated | BooruOptions.LimitOf20000 | BooruOptions.CommentApiXml)
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/Template/Gelbooru.cs
+++ b/BooruSharp/Booru/Template/Gelbooru.cs
@@ -18,15 +18,6 @@ namespace BooruSharp.Booru.Template
         /// Initializes a new instance of the <see cref="Gelbooru"/> template class.
         /// </summary>
         /// <param name="url">The base URL to use. This should be a host name.</param>
-        /// <param name="options">The collection of option values.</param>
-        [Obsolete(_deprecationMessage)]
-        public Gelbooru(string url, params BooruOptions[] options) : this(url, MergeOptions(options))
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Gelbooru"/> template class.
-        /// </summary>
-        /// <param name="url">The base URL to use. This should be a host name.</param>
         /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
         public Gelbooru(string url, BooruOptions options = BooruOptions.None) : base(url, UrlFormat.IndexPhp, options |
              BooruOptions.NoWiki | BooruOptions.NoRelated | BooruOptions.LimitOf20000 | BooruOptions.CommentApiXml)

--- a/BooruSharp/Booru/Template/Gelbooru02.cs
+++ b/BooruSharp/Booru/Template/Gelbooru02.cs
@@ -40,8 +40,8 @@ namespace BooruSharp.Booru.Template
         private protected override Search.Post.SearchResult GetPostSearchResult(JToken elem)
         {
             return new Search.Post.SearchResult(
-                new Uri("http" + (UsesHttp() ? "" : "s") + "://" + _url + "//images/" + elem["directory"].Value<string>() + "/" + elem["image"].Value<string>()),
-                new Uri("http" + (UsesHttp() ? "" : "s") + "://" + _url + "//thumbnails/" + elem["directory"].Value<string>() + "/thumbnails_" + elem["image"].Value<string>()),
+                new Uri("http" + (UsesHttp ? "" : "s") + "://" + _url + "//images/" + elem["directory"].Value<string>() + "/" + elem["image"].Value<string>()),
+                new Uri("http" + (UsesHttp ? "" : "s") + "://" + _url + "//thumbnails/" + elem["directory"].Value<string>() + "/thumbnails_" + elem["image"].Value<string>()),
                 new Uri(_baseUrl + "/index.php?page=post&s=view&id=" + elem["id"].Value<int>()),
                 GetRating(elem["rating"].Value<string>()[0]),
                 elem["tags"].Value<string>().Split(' '),

--- a/BooruSharp/Booru/Template/Gelbooru02.cs
+++ b/BooruSharp/Booru/Template/Gelbooru02.cs
@@ -25,8 +25,8 @@ namespace BooruSharp.Booru.Template
         /// </summary>
         /// <param name="url">The base URL to use. This should be a host name.</param>
         /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
-        public Gelbooru02(string url, BooruOptions options = BooruOptions.none) : base(url, UrlFormat.indexPhp, options |
-             BooruOptions.noRelated | BooruOptions.noWiki | BooruOptions.noPostByMd5 | BooruOptions.commentApiXml | BooruOptions.tagApiXml | BooruOptions.noMultipleRandom)
+        public Gelbooru02(string url, BooruOptions options = BooruOptions.None) : base(url, UrlFormat.IndexPhp, options |
+             BooruOptions.NoRelated | BooruOptions.NoWiki | BooruOptions.NoPostByMD5 | BooruOptions.CommentApiXml | BooruOptions.TagApiXml | BooruOptions.NoMultipleRandom)
         {
             _url = url;
         }

--- a/BooruSharp/Booru/Template/Gelbooru02.cs
+++ b/BooruSharp/Booru/Template/Gelbooru02.cs
@@ -15,15 +15,6 @@ namespace BooruSharp.Booru.Template
         /// Initializes a new instance of the <see cref="Gelbooru02"/> template class.
         /// </summary>
         /// <param name="url">The base URL to use. This should be a host name.</param>
-        /// <param name="options">The collection of option values.</param>
-        [Obsolete(_deprecationMessage)]
-        public Gelbooru02(string url, params BooruOptions[] options) : this(url, MergeOptions(options))
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Gelbooru02"/> template class.
-        /// </summary>
-        /// <param name="url">The base URL to use. This should be a host name.</param>
         /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
         public Gelbooru02(string url, BooruOptions options = BooruOptions.None) : base(url, UrlFormat.IndexPhp, options |
              BooruOptions.NoRelated | BooruOptions.NoWiki | BooruOptions.NoPostByMD5 | BooruOptions.CommentApiXml | BooruOptions.TagApiXml | BooruOptions.NoMultipleRandom)

--- a/BooruSharp/Booru/Template/Gelbooru02.cs
+++ b/BooruSharp/Booru/Template/Gelbooru02.cs
@@ -16,8 +16,9 @@ namespace BooruSharp.Booru.Template
         /// </summary>
         /// <param name="url">The base URL to use. This should be a host name.</param>
         /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
-        public Gelbooru02(string url, BooruOptions options = BooruOptions.None) : base(url, UrlFormat.IndexPhp, options |
-             BooruOptions.NoRelated | BooruOptions.NoWiki | BooruOptions.NoPostByMD5 | BooruOptions.CommentApiXml | BooruOptions.TagApiXml | BooruOptions.NoMultipleRandom)
+        protected Gelbooru02(string url, BooruOptions options = BooruOptions.None) 
+            : base(url, UrlFormat.IndexPhp, options | BooruOptions.NoRelated | BooruOptions.NoWiki | BooruOptions.NoPostByMD5
+                  | BooruOptions.CommentApiXml | BooruOptions.TagApiXml | BooruOptions.NoMultipleRandom)
         {
             _url = url;
         }
@@ -30,9 +31,12 @@ namespace BooruSharp.Booru.Template
 
         private protected override Search.Post.SearchResult GetPostSearchResult(JToken elem)
         {
+            string directory = elem["directory"].Value<string>();
+            string image = elem["image"].Value<string>();
+
             return new Search.Post.SearchResult(
-                new Uri("http" + (UsesHttp ? "" : "s") + "://" + _url + "//images/" + elem["directory"].Value<string>() + "/" + elem["image"].Value<string>()),
-                new Uri("http" + (UsesHttp ? "" : "s") + "://" + _url + "//thumbnails/" + elem["directory"].Value<string>() + "/thumbnails_" + elem["image"].Value<string>()),
+                new Uri("http" + (UsesHttp ? "" : "s") + "://" + _url + "//images/" + directory + "/" + image),
+                new Uri("http" + (UsesHttp ? "" : "s") + "://" + _url + "//thumbnails/" + directory + "/thumbnails_" + image),
                 new Uri(_baseUrl + "/index.php?page=post&s=view&id=" + elem["id"].Value<int>()),
                 GetRating(elem["rating"].Value<string>()[0]),
                 elem["tags"].Value<string>().Split(' '),

--- a/BooruSharp/Booru/Template/Moebooru.cs
+++ b/BooruSharp/Booru/Template/Moebooru.cs
@@ -13,15 +13,6 @@ namespace BooruSharp.Booru.Template
         /// Initializes a new instance of the <see cref="Moebooru"/> template class.
         /// </summary>
         /// <param name="url">The base URL to use. This should be a host name.</param>
-        /// <param name="options">The collection of option values.</param>
-        [Obsolete(_deprecationMessage)]
-        public Moebooru(string url, params BooruOptions[] options) : this(url, MergeOptions(options))
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Moebooru"/> template class.
-        /// </summary>
-        /// <param name="url">The base URL to use. This should be a host name.</param>
         /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
         public Moebooru(string url, BooruOptions options = BooruOptions.None) : base(url, UrlFormat.PostIndexJson, options | BooruOptions.NoPostByMD5 | BooruOptions.NoPostByID | BooruOptions.NoFavorite)
         { }

--- a/BooruSharp/Booru/Template/Moebooru.cs
+++ b/BooruSharp/Booru/Template/Moebooru.cs
@@ -23,7 +23,7 @@ namespace BooruSharp.Booru.Template
         /// </summary>
         /// <param name="url">The base URL to use. This should be a host name.</param>
         /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
-        public Moebooru(string url, BooruOptions options = BooruOptions.none) : base(url, UrlFormat.postIndexJson, options | BooruOptions.noPostByMd5 | BooruOptions.noPostById | BooruOptions.noFavorite)
+        public Moebooru(string url, BooruOptions options = BooruOptions.None) : base(url, UrlFormat.PostIndexJson, options | BooruOptions.NoPostByMD5 | BooruOptions.NoPostByID | BooruOptions.NoFavorite)
         { }
 
         private protected override JToken ParseFirstPostSearchResult(object json)

--- a/BooruSharp/Booru/Template/Moebooru.cs
+++ b/BooruSharp/Booru/Template/Moebooru.cs
@@ -14,7 +14,9 @@ namespace BooruSharp.Booru.Template
         /// </summary>
         /// <param name="url">The base URL to use. This should be a host name.</param>
         /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
-        public Moebooru(string url, BooruOptions options = BooruOptions.None) : base(url, UrlFormat.PostIndexJson, options | BooruOptions.NoPostByMD5 | BooruOptions.NoPostByID | BooruOptions.NoFavorite)
+        protected Moebooru(string url, BooruOptions options = BooruOptions.None)
+            : base(url, UrlFormat.PostIndexJson, options | BooruOptions.NoPostByMD5 | BooruOptions.NoPostByID
+                  | BooruOptions.NoFavorite)
         { }
 
         private protected override JToken ParseFirstPostSearchResult(object json)

--- a/BooruSharp/Booru/Template/Sankaku.cs
+++ b/BooruSharp/Booru/Template/Sankaku.cs
@@ -14,7 +14,9 @@ namespace BooruSharp.Booru.Template
         /// </summary>
         /// <param name="url">The base URL to use. This should be a host name.</param>
         /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
-        public Sankaku(string url, BooruOptions options = BooruOptions.None) : base(url, UrlFormat.Sankaku, options | BooruOptions.NoRelated | BooruOptions.NoPostByMD5 | BooruOptions.NoPostByID | BooruOptions.NoPostCount | BooruOptions.NoFavorite | BooruOptions.NoTagByID)
+        protected Sankaku(string url, BooruOptions options = BooruOptions.None)
+            : base(url, UrlFormat.Sankaku, options | BooruOptions.NoRelated | BooruOptions.NoPostByMD5 | BooruOptions.NoPostByID
+                  | BooruOptions.NoPostCount | BooruOptions.NoFavorite | BooruOptions.NoTagByID)
         { }
 
         private protected override JToken ParseFirstPostSearchResult(object json)

--- a/BooruSharp/Booru/Template/Sankaku.cs
+++ b/BooruSharp/Booru/Template/Sankaku.cs
@@ -23,7 +23,7 @@ namespace BooruSharp.Booru.Template
         /// </summary>
         /// <param name="url">The base URL to use. This should be a host name.</param>
         /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
-        public Sankaku(string url, BooruOptions options = BooruOptions.none) : base(url, UrlFormat.sankaku, options | BooruOptions.noRelated | BooruOptions.noPostByMd5 | BooruOptions.noPostById | BooruOptions.noPostCount | BooruOptions.noFavorite | BooruOptions.noTagById)
+        public Sankaku(string url, BooruOptions options = BooruOptions.None) : base(url, UrlFormat.Sankaku, options | BooruOptions.NoRelated | BooruOptions.NoPostByMD5 | BooruOptions.NoPostByID | BooruOptions.NoPostCount | BooruOptions.NoFavorite | BooruOptions.NoTagByID)
         { }
 
         private protected override JToken ParseFirstPostSearchResult(object json)

--- a/BooruSharp/Booru/Template/Sankaku.cs
+++ b/BooruSharp/Booru/Template/Sankaku.cs
@@ -13,15 +13,6 @@ namespace BooruSharp.Booru.Template
         /// Initializes a new instance of the <see cref="Sankaku"/> template class.
         /// </summary>
         /// <param name="url">The base URL to use. This should be a host name.</param>
-        /// <param name="options">The collection of option values.</param>
-        [Obsolete(_deprecationMessage)]
-        public Sankaku(string url, params BooruOptions[] options) : this(url, MergeOptions(options))
-        { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Sankaku"/> template class.
-        /// </summary>
-        /// <param name="url">The base URL to use. This should be a host name.</param>
         /// <param name="options">The options to use. Use | (bitwise OR) operator to combine multiple options.</param>
         public Sankaku(string url, BooruOptions options = BooruOptions.None) : base(url, UrlFormat.Sankaku, options | BooruOptions.NoRelated | BooruOptions.NoPostByMD5 | BooruOptions.NoPostByID | BooruOptions.NoPostCount | BooruOptions.NoFavorite | BooruOptions.NoTagByID)
         { }

--- a/BooruSharp/Booru/UrlFormat.cs
+++ b/BooruSharp/Booru/UrlFormat.cs
@@ -8,18 +8,18 @@
         /// <summary>
         /// Indicates that the API uses <c>/post/index.json</c> query scheme.
         /// </summary>
-        postIndexJson,
+        PostIndexJson,
         /// <summary>
         /// Indicates that the API uses <c>/index.php?page=dapi&amp;s=post&amp;q=index&amp;json=1</c> query scheme.
         /// </summary>
-        indexPhp,
+        IndexPhp,
         /// <summary>
         /// Indicates that the API uses <c>/posts.json</c> query scheme.
         /// </summary>
-        danbooru,
+        Danbooru,
         /// <summary>
         /// Indicates that the API uses <c>/posts</c> query scheme.
         /// </summary>
-        sankaku
+        Sankaku
     }
 }

--- a/BooruSharp/Booru/UrlFormat.cs
+++ b/BooruSharp/Booru/UrlFormat.cs
@@ -6,6 +6,11 @@
     public enum UrlFormat
     {
         /// <summary>
+        /// Indicates that the API doesn't use any particular query
+        /// scheme and requires custom logic to handle requests.
+        /// </summary>
+        None,
+        /// <summary>
         /// Indicates that the API uses <c>/post/index.json</c> query scheme.
         /// </summary>
         PostIndexJson,

--- a/BooruSharp/Booru/Xbooru.cs
+++ b/BooruSharp/Booru/Xbooru.cs
@@ -13,6 +13,6 @@
         { }
 
         /// <inheritdoc/>
-        public override bool IsSafe() => false;
+        public override bool IsSafe => false;
     }
 }

--- a/BooruSharp/Booru/Xbooru.cs
+++ b/BooruSharp/Booru/Xbooru.cs
@@ -9,7 +9,8 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Xbooru"/> class.
         /// </summary>
-        public Xbooru() : base("xbooru.com")
+        public Xbooru()
+            : base("xbooru.com")
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/Yandere.cs
+++ b/BooruSharp/Booru/Yandere.cs
@@ -9,7 +9,8 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Yandere"/> class.
         /// </summary>
-        public Yandere() : base("yande.re", BooruOptions.NoLastComments)
+        public Yandere()
+            : base("yande.re", BooruOptions.NoLastComments)
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Booru/Yandere.cs
+++ b/BooruSharp/Booru/Yandere.cs
@@ -13,6 +13,6 @@
         { }
 
         /// <inheritdoc/>
-        public override bool IsSafe() => false;
+        public override bool IsSafe => false;
     }
 }

--- a/BooruSharp/Booru/Yandere.cs
+++ b/BooruSharp/Booru/Yandere.cs
@@ -9,7 +9,7 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Yandere"/> class.
         /// </summary>
-        public Yandere() : base("yande.re", BooruOptions.noLastComments)
+        public Yandere() : base("yande.re", BooruOptions.NoLastComments)
         { }
 
         /// <inheritdoc/>

--- a/BooruSharp/Search/AuthentificationInvalid.cs
+++ b/BooruSharp/Search/AuthentificationInvalid.cs
@@ -11,7 +11,8 @@ namespace BooruSharp.Search
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthentificationInvalid"/> class.
         /// </summary>
-        public AuthentificationInvalid() : base("Your credentials are invalid")
+        public AuthentificationInvalid()
+            : base("Your credentials are invalid")
         { }
     }
 }

--- a/BooruSharp/Search/AuthentificationRequired.cs
+++ b/BooruSharp/Search/AuthentificationRequired.cs
@@ -11,7 +11,8 @@ namespace BooruSharp.Search
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthentificationRequired"/> class.
         /// </summary>
-        public AuthentificationRequired() : base("Authentification is required for this feature")
+        public AuthentificationRequired()
+            : base("Authentification is required for this feature")
         { }
     }
 }

--- a/BooruSharp/Search/Comment/ABooru.cs
+++ b/BooruSharp/Search/Comment/ABooru.cs
@@ -31,7 +31,7 @@ namespace BooruSharp.Booru
                 {
                     var result = GetCommentSearchResult(node);
 
-                    if (result.postId == postId)
+                    if (result.PostID == postId)
                         results.Add(result);
                 }
             }
@@ -43,7 +43,7 @@ namespace BooruSharp.Booru
                 {
                     var result = GetCommentSearchResult(json);
 
-                    if (result.postId == postId)
+                    if (result.PostID == postId)
                         results.Add(result);
                 }
             }

--- a/BooruSharp/Search/Comment/ABooru.cs
+++ b/BooruSharp/Search/Comment/ABooru.cs
@@ -17,13 +17,13 @@ namespace BooruSharp.Booru
         /// <exception cref="System.Net.Http.HttpRequestException"/>
         public virtual async Task<Search.Comment.SearchResult[]> GetCommentsAsync(int postId)
         {
-            if (!HasCommentAPI())
+            if (!HasCommentAPI)
                 throw new Search.FeatureUnavailable();
 
             var url = CreateUrl(_commentUrl, SearchArg("post_id") + postId);
             var results = new List<Search.Comment.SearchResult>();
 
-            if (CommentsUseXml())
+            if (CommentsUseXml)
             {
                 var xml = await GetXmlAsync(url);
 
@@ -59,12 +59,12 @@ namespace BooruSharp.Booru
         /// <exception cref="System.Net.Http.HttpRequestException"/>
         public virtual async Task<Search.Comment.SearchResult[]> GetLastCommentsAsync()
         {
-            if (!HasSearchLastComment())
+            if (!HasSearchLastComment)
                 throw new Search.FeatureUnavailable();
 
             string url = CreateUrl(_commentUrl);
 
-            if (CommentsUseXml())
+            if (CommentsUseXml)
             {
                 var xml = await GetXmlAsync(url);
                 var results = new List<Search.Comment.SearchResult>(xml.LastChild.ChildNodes.Count);

--- a/BooruSharp/Search/Comment/SearchResult.cs
+++ b/BooruSharp/Search/Comment/SearchResult.cs
@@ -5,7 +5,7 @@ namespace BooruSharp.Search.Comment
     /// <summary>
     /// Represents a comment API search result.
     /// </summary>
-    public struct SearchResult
+    public readonly struct SearchResult
     {
         /// <summary>
         /// Initializes a <see cref="SearchResult"/> struct. 
@@ -19,43 +19,43 @@ namespace BooruSharp.Search.Comment
         /// <param name="body">The comment's message.</param>
         public SearchResult(int commentId, int postId, int? authorId, DateTime creation, string authorName, string body)
         {
-            this.commentId = commentId;
-            this.postId = postId;
-            this.authorId = authorId;
-            this.creation = creation;
-            this.authorName = authorName;
-            this.body = body;
+            CommentID = commentId;
+            PostID = postId;
+            AuthorID = authorId;
+            Creation = creation;
+            AuthorName = authorName;
+            Body = body;
         }
 
         /// <summary>
         /// Gets the ID of the comment.
         /// </summary>
-        public readonly int commentId;
+        public int CommentID { get; }
 
         /// <summary>
         /// Gets the ID of the image associated with the comment.
         /// </summary>
-        public readonly int postId;
+        public int PostID { get; }
 
         /// <summary>
         /// Gets the ID of the author of the comment, or
         /// <see langword="null"/> if the author is anonymous.
         /// </summary>
-        public readonly int? authorId;
+        public int? AuthorID { get; }
 
         /// <summary>
         /// Gets the date when the comment was posted.
         /// </summary>
-        public readonly DateTime creation;
+        public DateTime Creation { get; }
 
         /// <summary>
         /// Gets the name of the author of the comment.
         /// </summary>
-        public readonly string authorName;
+        public string AuthorName { get; }
 
         /// <summary>
         /// Gets the comment's message.
         /// </summary>
-        public readonly string body;
+        public string Body { get; }
     }
 }

--- a/BooruSharp/Search/Favorite/ABooru.cs
+++ b/BooruSharp/Search/Favorite/ABooru.cs
@@ -22,7 +22,7 @@ namespace BooruSharp.Booru
         /// <exception cref="InvalidPostId"/>
         public virtual async Task AddFavoriteAsync(int postId)
         {
-            if (!HasFavoriteAPI())
+            if (!HasFavoriteAPI)
                 throw new FeatureUnavailable();
 
             if (Auth == null)
@@ -54,7 +54,7 @@ namespace BooruSharp.Booru
         /// <exception cref="System.Net.Http.HttpRequestException"/>
         public virtual async Task RemoveFavoriteAsync(int postId)
         {
-            if (!HasFavoriteAPI())
+            if (!HasFavoriteAPI)
                 throw new FeatureUnavailable();
 
             if (Auth == null)

--- a/BooruSharp/Search/FeatureUnavailable.cs
+++ b/BooruSharp/Search/FeatureUnavailable.cs
@@ -11,7 +11,8 @@ namespace BooruSharp.Search
         /// <summary>
         /// Initializes a new instance of the <see cref="FeatureUnavailable"/> class.
         /// </summary>
-        public FeatureUnavailable() : base("This feature isn't available for this Booru")
+        public FeatureUnavailable()
+            : base("This feature isn't available for this Booru")
         { }
     }
 }

--- a/BooruSharp/Search/InvalidPostId.cs
+++ b/BooruSharp/Search/InvalidPostId.cs
@@ -11,13 +11,15 @@
         /// class with a specified error message.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
-        public InvalidPostId(string message) : base(message)
+        public InvalidPostId(string message)
+            : base(message)
         { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InvalidPostId"/> class.
         /// </summary>
-        public InvalidPostId() : base("There is no post with this id")
+        public InvalidPostId()
+            : base("There is no post with this id")
         { }
     }
 }

--- a/BooruSharp/Search/InvalidTags.cs
+++ b/BooruSharp/Search/InvalidTags.cs
@@ -9,7 +9,8 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="InvalidTags"/> class.
         /// </summary>
-        public InvalidTags() : base("There is nothing available with these tags")
+        public InvalidTags()
+            : base("There is nothing available with these tags")
         { }
     }
 }

--- a/BooruSharp/Search/Post/ABooru.cs
+++ b/BooruSharp/Search/Post/ABooru.cs
@@ -18,7 +18,7 @@ namespace BooruSharp.Booru
         /// <exception cref="System.Net.Http.HttpRequestException"/>
         public virtual async Task<Search.Post.SearchResult> GetPostByMd5Async(string md5)
         {
-            if (!HasPostByMd5API())
+            if (!HasPostByMd5API)
                 throw new Search.FeatureUnavailable();
 
             if (md5 == null)
@@ -36,7 +36,7 @@ namespace BooruSharp.Booru
         /// <exception cref="System.Net.Http.HttpRequestException"/>
         public virtual async Task<Search.Post.SearchResult> GetPostByIdAsync(int id)
         {
-            if (!HasPostByIdAPI())
+            if (!HasPostByIdAPI)
                 throw new Search.FeatureUnavailable();
 
             return _format == UrlFormat.Danbooru
@@ -55,14 +55,14 @@ namespace BooruSharp.Booru
         /// <exception cref="Search.TooManyTags"/>
         public virtual async Task<int> GetPostCountAsync(params string[] tagsArg)
         {
-            if (!HasPostCountAPI())
+            if (!HasPostCountAPI)
                 throw new Search.FeatureUnavailable();
 
             string[] tags = tagsArg != null
                 ? tagsArg.Where(tag => !string.IsNullOrWhiteSpace(tag)).ToArray()
                 : Array.Empty<string>();
 
-            if (tags.Length > 2 && NoMoreThanTwoTags())
+            if (tags.Length > 2 && NoMoreThanTwoTags)
                 throw new Search.TooManyTags();
 
             XmlDocument xml = await GetXmlAsync(CreateUrl(_imageUrlXml, "limit=1", TagsToString(tags)));
@@ -83,7 +83,7 @@ namespace BooruSharp.Booru
                 ? tagsArg.Where(tag => !string.IsNullOrWhiteSpace(tag)).ToArray()
                 : Array.Empty<string>();
 
-            if (tags.Length > 2 && NoMoreThanTwoTags())
+            if (tags.Length > 2 && NoMoreThanTwoTags)
                 throw new Search.TooManyTags();
 
             if (_format == UrlFormat.IndexPhp)
@@ -102,13 +102,13 @@ namespace BooruSharp.Booru
                 if (max == 0)
                     throw new Search.InvalidTags();
 
-                if (SearchIncreasedPostLimit() && max > 20001)
+                if (SearchIncreasedPostLimit && max > 20001)
                     max = 20001;
 
                 return await GetSearchResultFromUrlAsync(CreateUrl(_imageUrl, "limit=1", TagsToString(tags), "pid=" + _random.Next(0, max)));
             }
 
-            return NoMoreThanTwoTags()
+            return NoMoreThanTwoTags
                 ? await GetSearchResultFromUrlAsync(CreateUrl(_imageUrl, "limit=1", TagsToString(tags), "random=true")) // +order:random count as a tag so we use random=true instead to save one
                 : await GetSearchResultFromUrlAsync(CreateUrl(_imageUrl, "limit=1", TagsToString(tags)) + "+order:random");
         }
@@ -125,19 +125,19 @@ namespace BooruSharp.Booru
         /// <exception cref="Search.TooManyTags"/>
         public virtual async Task<Search.Post.SearchResult[]> GetRandomPostsAsync(int limit, params string[] tagsArg)
         {
-            if (!HasMultipleRandomAPI())
+            if (!HasMultipleRandomAPI)
                 throw new Search.FeatureUnavailable();
 
             string[] tags = tagsArg != null
                 ? tagsArg.Where(tag => !string.IsNullOrWhiteSpace(tag)).ToArray()
                 : Array.Empty<string>();
 
-            if (tags.Length > 2 && NoMoreThanTwoTags())
+            if (tags.Length > 2 && NoMoreThanTwoTags)
                 throw new Search.TooManyTags();
 
             if (_format == UrlFormat.IndexPhp)
                 return await GetSearchResultsFromUrlAsync(CreateUrl(_imageUrl, "limit=" + limit, TagsToString(tags)) + "+sort:random");
-            else if (NoMoreThanTwoTags())
+            else if (NoMoreThanTwoTags)
                 return await GetSearchResultsFromUrlAsync(CreateUrl(_imageUrl, "limit=" + limit, TagsToString(tags), "random=true")); // +order:random count as a tag so we use random=true instead to save one
             else
                 return await GetSearchResultsFromUrlAsync(CreateUrl(_imageUrl, "limit=" + limit, TagsToString(tags)) + "+order:random");

--- a/BooruSharp/Search/Post/ABooru.cs
+++ b/BooruSharp/Search/Post/ABooru.cs
@@ -39,7 +39,7 @@ namespace BooruSharp.Booru
             if (!HasPostByIdAPI())
                 throw new Search.FeatureUnavailable();
 
-            return _format == UrlFormat.danbooru
+            return _format == UrlFormat.Danbooru
                 ? await GetSearchResultFromUrlAsync(_baseUrl + "/posts/" + id + ".json")
                 : await GetSearchResultFromUrlAsync(CreateUrl(_imageUrl, "limit=1", "id=" + id));
         }
@@ -86,7 +86,7 @@ namespace BooruSharp.Booru
             if (tags.Length > 2 && NoMoreThanTwoTags())
                 throw new Search.TooManyTags();
 
-            if (_format == UrlFormat.indexPhp)
+            if (_format == UrlFormat.IndexPhp)
             {
                 if (this is Template.Gelbooru)
                     return await GetSearchResultFromUrlAsync(CreateUrl(_imageUrl, "limit=1", TagsToString(tags)) + "+sort:random");
@@ -135,7 +135,7 @@ namespace BooruSharp.Booru
             if (tags.Length > 2 && NoMoreThanTwoTags())
                 throw new Search.TooManyTags();
 
-            if (_format == UrlFormat.indexPhp)
+            if (_format == UrlFormat.IndexPhp)
                 return await GetSearchResultsFromUrlAsync(CreateUrl(_imageUrl, "limit=" + limit, TagsToString(tags)) + "+sort:random");
             else if (NoMoreThanTwoTags())
                 return await GetSearchResultsFromUrlAsync(CreateUrl(_imageUrl, "limit=" + limit, TagsToString(tags), "random=true")); // +order:random count as a tag so we use random=true instead to save one

--- a/BooruSharp/Search/Post/SearchResult.cs
+++ b/BooruSharp/Search/Post/SearchResult.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace BooruSharp.Search.Post
 {
@@ -25,14 +27,14 @@ namespace BooruSharp.Search.Post
         /// <param name="source">The original source of the file.</param>
         /// <param name="score">The score of the post.</param>
         /// <param name="md5">The MD5 hash of the file.</param>
-        public SearchResult(Uri fileUrl, Uri previewUrl, Uri postUrl, Rating rating, string[] tags, int id,
+        public SearchResult(Uri fileUrl, Uri previewUrl, Uri postUrl, Rating rating, IList<string> tags, int id,
                             int? size, int height, int width, int? previewHeight, int? previewWidth, DateTime? creation, string source, int? score, string md5)
         {
             FileUrl = fileUrl;
             PreviewUrl = previewUrl;
             PostUrl = postUrl;
             Rating = rating;
-            Tags = tags;
+            Tags = new ReadOnlyCollection<string>(tags);
             ID = id;
             Size = size;
             Height = height;
@@ -66,9 +68,9 @@ namespace BooruSharp.Search.Post
         public Rating Rating { get; }
 
         /// <summary>
-        /// Gets the array containing all the tags associated with the file.
+        /// Gets the read-only collection containing all the tags associated with the file.
         /// </summary>
-        public string[] Tags { get; }
+        public ReadOnlyCollection<string> Tags { get; }
 
         /// <summary>
         /// Gets the ID of the post.

--- a/BooruSharp/Search/Post/SearchResult.cs
+++ b/BooruSharp/Search/Post/SearchResult.cs
@@ -5,7 +5,7 @@ namespace BooruSharp.Search.Post
     /// <summary>
     /// Represents a post API search result.
     /// </summary>
-    public struct SearchResult
+    public readonly struct SearchResult
     {
         /// <summary>
         /// Initializes a <see cref="SearchResult"/> struct.
@@ -28,102 +28,102 @@ namespace BooruSharp.Search.Post
         public SearchResult(Uri fileUrl, Uri previewUrl, Uri postUrl, Rating rating, string[] tags, int id,
                             int? size, int height, int width, int? previewHeight, int? previewWidth, DateTime? creation, string source, int? score, string md5)
         {
-            this.fileUrl = fileUrl;
-            this.previewUrl = previewUrl;
-            this.postUrl = postUrl;
-            this.rating = rating;
-            this.tags = tags;
-            this.id = id;
-            this.size = size;
-            this.height = height;
-            this.width = width;
-            this.previewHeight = previewHeight;
-            this.previewWidth = previewWidth;
-            this.creation = creation;
-            this.source = source;
-            this.score = score;
-            this.md5 = md5;
+            FileUrl = fileUrl;
+            PreviewUrl = previewUrl;
+            PostUrl = postUrl;
+            Rating = rating;
+            Tags = tags;
+            ID = id;
+            Size = size;
+            Height = height;
+            Width = width;
+            PreviewHeight = previewHeight;
+            PreviewWidth = previewWidth;
+            Creation = creation;
+            Source = source;
+            Score = score;
+            MD5 = md5;
         }
 
         /// <summary>
         /// Gets the URI of the file.
         /// </summary>
-        public readonly Uri fileUrl;
+        public Uri FileUrl { get; }
 
         /// <summary>
         /// Gets the URI of the preview image.
         /// </summary>
-        public readonly Uri previewUrl;
+        public Uri PreviewUrl { get; }
 
         /// <summary>
         /// Gets the URI of the post.
         /// </summary>
-        public readonly Uri postUrl;
+        public Uri PostUrl { get; }
 
         /// <summary>
         /// Gets the post's rating.
         /// </summary>
-        public readonly Rating rating;
+        public Rating Rating { get; }
 
         /// <summary>
         /// Gets the array containing all the tags associated with the file.
         /// </summary>
-        public readonly string[] tags;
+        public string[] Tags { get; }
 
         /// <summary>
         /// Gets the ID of the post.
         /// </summary>
-        public readonly int id;
+        public int ID { get; }
 
         /// <summary>
         /// Gets the size of the file, in bytes, or
         /// <see langword="null"/> if file size is unknown.
         /// </summary>
-        public readonly int? size;
+        public int? Size { get; }
 
         /// <summary>
         /// Gets the height of the image, in pixels.
         /// </summary>
-        public readonly int height;
+        public int Height { get; }
 
         /// <summary>
         /// Gets the width of the image, in pixels.
         /// </summary>
-        public readonly int width;
+        public int Width { get; }
 
         /// <summary>
         /// Gets the height of the preview image, in pixels,
         /// or <see langword="null"/> if the height is unknown.
         /// </summary>
-        public readonly int? previewHeight;
+        public int? PreviewHeight { get; }
 
         /// <summary>
         /// Gets the width of the preview image, in pixels,
         /// or <see langword="null"/> if the width is unknown.
         /// </summary>
-        public readonly int? previewWidth;
+        public int? PreviewWidth { get; }
 
         /// <summary>
         /// Gets the creation date of the post, or
         /// <see langword="null"/> if the date is unknown.
         /// </summary>
-        public readonly DateTime? creation;
+        public DateTime? Creation { get; }
 
         /// <summary>
         /// Gets the original source of the file.
         /// </summary>
-        public readonly string source;
+        public string Source { get; }
 
         /// <summary>
         /// Gets the score of the post, or
         /// <see langword="null"/> if the score is unknown.
         /// </summary>
-        public readonly int? score;
+        public int? Score { get; }
 
         /// <summary>
         /// Gets the MD5 hash of the file, represented as
         /// a sequence of 32 hexadecimal lowercase digits.
         /// </summary>
-        public readonly string md5;
+        public string MD5 { get; }
     }
 }

--- a/BooruSharp/Search/Post/SearchResult.cs
+++ b/BooruSharp/Search/Post/SearchResult.cs
@@ -27,8 +27,10 @@ namespace BooruSharp.Search.Post
         /// <param name="source">The original source of the file.</param>
         /// <param name="score">The score of the post.</param>
         /// <param name="md5">The MD5 hash of the file.</param>
-        public SearchResult(Uri fileUrl, Uri previewUrl, Uri postUrl, Rating rating, IList<string> tags, int id,
-                            int? size, int height, int width, int? previewHeight, int? previewWidth, DateTime? creation, string source, int? score, string md5)
+        public SearchResult(
+            Uri fileUrl, Uri previewUrl, Uri postUrl, Rating rating, IList<string> tags,
+            int id, int? size, int height, int width, int? previewHeight, int? previewWidth,
+            DateTime? creation, string source, int? score, string md5)
         {
             FileUrl = fileUrl;
             PreviewUrl = previewUrl;

--- a/BooruSharp/Search/Related/ABooru.cs
+++ b/BooruSharp/Search/Related/ABooru.cs
@@ -24,7 +24,7 @@ namespace BooruSharp.Booru
             if (tag == null)
                 throw new ArgumentNullException(nameof(tag));
 
-            bool isDanbooruFormat = _format == UrlFormat.danbooru;
+            bool isDanbooruFormat = _format == UrlFormat.Danbooru;
 
             var content = JsonConvert.DeserializeObject<JObject>(
                 await GetJsonAsync(CreateUrl(_relatedUrl, (isDanbooruFormat ? "query" : "tags") + "=" + tag)));

--- a/BooruSharp/Search/Related/ABooru.cs
+++ b/BooruSharp/Search/Related/ABooru.cs
@@ -18,7 +18,7 @@ namespace BooruSharp.Booru
         /// <exception cref="System.Net.Http.HttpRequestException"/>
         public virtual async Task<Search.Related.SearchResult[]> GetRelatedAsync(string tag)
         {
-            if (!HasRelatedAPI())
+            if (!HasRelatedAPI)
                 throw new Search.FeatureUnavailable();
 
             if (tag == null)

--- a/BooruSharp/Search/Related/SearchResult.cs
+++ b/BooruSharp/Search/Related/SearchResult.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Represents a related API search result.
     /// </summary>
-    public struct SearchResult
+    public readonly struct SearchResult
     {
         /// <summary>
         /// Initializes a <see cref="SearchResult"/> struct.
@@ -12,19 +12,19 @@
         /// <param name="count">The number of occurences of the tag.</param>
         public SearchResult(string name, int? count)
         {
-            this.name = name;
-            this.count = count;
+            Name = name;
+            Count = count;
         }
 
         /// <summary>
         /// Gets the name of the tag.
         /// </summary>
-        public readonly string name;
+        public string Name { get; }
 
         /// <summary>
         /// Gets the number of occurences of the tag, or
         /// <see langword="null"/> if that number is unknown.
         /// </summary>
-        public readonly int? count;
+        public int? Count { get; }
     }
 }

--- a/BooruSharp/Search/Tag/ABooru.cs
+++ b/BooruSharp/Search/Tag/ABooru.cs
@@ -63,7 +63,7 @@ namespace BooruSharp.Booru
 
             var urlTags = new List<string>() { SearchArg("name") + name };
 
-            if (_format == UrlFormat.postIndexJson)
+            if (_format == UrlFormat.PostIndexJson)
                 urlTags.Add("limit=0");
 
             string url = CreateUrl(_tagUrl, urlTags.ToArray());
@@ -96,7 +96,7 @@ namespace BooruSharp.Booru
                 ? SearchArg("id") + id
                 : SearchArg("name") + name);
 
-            if (_format == UrlFormat.postIndexJson)
+            if (_format == UrlFormat.PostIndexJson)
                 urlTags.Add("limit=0");
 
             string url = CreateUrl(_tagUrl, urlTags.ToArray());

--- a/BooruSharp/Search/Tag/ABooru.cs
+++ b/BooruSharp/Search/Tag/ABooru.cs
@@ -20,7 +20,7 @@ namespace BooruSharp.Booru
         /// <exception cref="Search.InvalidTags"/>
         public virtual async Task<Search.Tag.SearchResult> GetTagAsync(string name)
         {
-            if (!HasTagByIdAPI())
+            if (!HasTagByIdAPI)
                 throw new Search.FeatureUnavailable();
 
             if (name == null)
@@ -39,7 +39,7 @@ namespace BooruSharp.Booru
         /// <exception cref="Search.InvalidTags"/>
         public virtual async Task<Search.Tag.SearchResult> GetTagAsync(int id)
         {
-            if (!HasTagByIdAPI())
+            if (!HasTagByIdAPI)
                 throw new Search.FeatureUnavailable();
 
             return await SearchTagAsync(null, id);
@@ -55,7 +55,7 @@ namespace BooruSharp.Booru
         /// <exception cref="System.Net.Http.HttpRequestException"/>
         public virtual async Task<Search.Tag.SearchResult[]> GetTagsAsync(string name)
         {
-            if (!HasTagByIdAPI())
+            if (!HasTagByIdAPI)
                 throw new Search.FeatureUnavailable();
 
             if (name == null)
@@ -68,7 +68,7 @@ namespace BooruSharp.Booru
 
             string url = CreateUrl(_tagUrl, urlTags.ToArray());
 
-            if (TagsUseXml())
+            if (TagsUseXml)
             {
                 var xml = await GetXmlAsync(url);
                 // Can't use LINQ with XmlNodes so let's use list here.
@@ -100,8 +100,7 @@ namespace BooruSharp.Booru
                 urlTags.Add("limit=0");
 
             string url = CreateUrl(_tagUrl, urlTags.ToArray());
-
-            if (TagsUseXml())
+            if (TagsUseXml)
             {
                 var xml = await GetXmlAsync(url);
 

--- a/BooruSharp/Search/Tag/ABooru.cs
+++ b/BooruSharp/Search/Tag/ABooru.cs
@@ -109,7 +109,7 @@ namespace BooruSharp.Booru
                 {
                     var result = GetTagSearchResult(node);
 
-                    if ((name == null && id == result.id) || (name != null && name == result.name))
+                    if ((name == null && id == result.ID) || (name != null && name == result.Name))
                         return result;
                 }
             }
@@ -121,7 +121,7 @@ namespace BooruSharp.Booru
                 {
                     var result = GetTagSearchResult(json);
 
-                    if ((name == null && id == result.id) || (name != null && name == result.name))
+                    if ((name == null && id == result.ID) || (name != null && name == result.Name))
                         return result;
                 }
             }

--- a/BooruSharp/Search/Tag/SearchResult.cs
+++ b/BooruSharp/Search/Tag/SearchResult.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Represents a tag API search result.
     /// </summary>
-    public struct SearchResult
+    public readonly struct SearchResult
     {
         /// <summary>
         /// Initializes a <see cref="SearchResult"/> struct.
@@ -14,30 +14,30 @@
         /// <param name="count">The number of occurences of the tag.</param>
         public SearchResult(int id, string name, TagType type, int count)
         {
-            this.id = id;
-            this.name = name;
-            this.type = type;
-            this.count = count;
+            ID = id;
+            Name = name;
+            Type = type;
+            Count = count;
         }
 
         /// <summary>
         /// Gets the ID of the tag.
         /// </summary>
-        public readonly int id;
+        public int ID { get; }
 
         /// <summary>
         /// Gets the name of the tag.
         /// </summary>
-        public readonly string name;
+        public string Name { get; }
 
         /// <summary>
         /// Gets the type of the tag.
         /// </summary>
-        public readonly TagType type;
+        public TagType Type { get; }
 
         /// <summary>
         /// Gets the number of occurences of the tag.
         /// </summary>
-        public readonly int count;
+        public int Count { get; }
     }
 }

--- a/BooruSharp/Search/TooManyTags.cs
+++ b/BooruSharp/Search/TooManyTags.cs
@@ -9,7 +9,8 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="TooManyTags"/> class.
         /// </summary>
-        public TooManyTags() : base("You can't have more than 2 tags for a search with this booru")
+        public TooManyTags()
+            : base("You can't have more than 2 tags for a search with this booru")
         { }
     }
 }

--- a/BooruSharp/Search/Wiki/ABooru.cs
+++ b/BooruSharp/Search/Wiki/ABooru.cs
@@ -18,7 +18,7 @@ namespace BooruSharp.Booru
         /// <exception cref="Search.InvalidTags"/>
         public virtual async Task<Search.Wiki.SearchResult> GetWikiAsync(string query)
         {
-            if (!HasWikiAPI())
+            if (!HasWikiAPI)
                 throw new Search.FeatureUnavailable();
 
             if (query == null)

--- a/BooruSharp/Search/Wiki/ABooru.cs
+++ b/BooruSharp/Search/Wiki/ABooru.cs
@@ -25,7 +25,7 @@ namespace BooruSharp.Booru
                 throw new ArgumentNullException(nameof(query));
 
             var array = JsonConvert.DeserializeObject<JArray>(
-                await GetJsonAsync(CreateUrl(_wikiUrl, SearchArg(_format == UrlFormat.danbooru ? "title" : "query") + query)));
+                await GetJsonAsync(CreateUrl(_wikiUrl, SearchArg(_format == UrlFormat.Danbooru ? "title" : "query") + query)));
 
             foreach (var token in array)
                 if (token["title"].Value<string>() == query)

--- a/BooruSharp/Search/Wiki/SearchResult.cs
+++ b/BooruSharp/Search/Wiki/SearchResult.cs
@@ -5,7 +5,7 @@ namespace BooruSharp.Search.Wiki
     /// <summary>
     /// Represents a wiki entry API search result.
     /// </summary>
-    public struct SearchResult
+    public readonly struct SearchResult
     {
         /// <summary>
         /// Initializes a <see cref="SearchResult"/> struct.
@@ -17,36 +17,36 @@ namespace BooruSharp.Search.Wiki
         /// <param name="body">The tag description.</param>
         public SearchResult(int id, string title, DateTime creation, DateTime lastUpdate, string body)
         {
-            this.id = id;
-            this.title = title;
-            this.creation = creation;
-            this.lastUpdate = lastUpdate;
-            this.body = body;
+            ID = id;
+            Title = title;
+            Creation = creation;
+            LastUpdate = lastUpdate;
+            Body = body;
         }
 
         /// <summary>
         /// Gets the ID of the wiki entry.
         /// </summary>
-        public readonly int id;
+        public int ID { get; }
 
         /// <summary>
         /// Gets the name of the described tag.
         /// </summary>
-        public readonly string title;
+        public string Title { get; }
 
         /// <summary>
         /// Gets the date when the wiki entry was created.
         /// </summary>
-        public readonly DateTime creation;
+        public DateTime Creation { get; }
 
         /// <summary>
         /// Gets the date of the latest update to the wiki entry.
         /// </summary>
-        public readonly DateTime lastUpdate;
+        public DateTime LastUpdate { get; }
 
         /// <summary>
         /// Gets the tag description.
         /// </summary>
-        public readonly string body;
+        public string Body { get; }
     }
 }


### PR DESCRIPTION
**This PR breaks a lot of public API so a major version bump at some point in the future is warranted.**

This PR changes a lot of stuff in order to make the library stand up to .NET code conventions and standards.

- Forced PascalCase naming convention on enum values and public properties
- Reworked existing `SearchResult` structs:
  - Added `readonly` modifier to structs declaration
  - Turned fields into read-only properties
  - `Search.Post.SearchResult`'s `Tags` property now gets a read-only collection of `string`s and not the regular `string[]` array
- Replaced property-like methods of `ABooru` class with actual properties that describe the object's state
- Removed members marked with `ObsoleteAttribute` and other members related to those
- Various code style readability improvements