### PR TITLE
Improve Pixiv authorization

### DIFF
--- a/BooruSharp.UnitTests/BooruTests.cs
+++ b/BooruSharp.UnitTests/BooruTests.cs
@@ -125,7 +125,7 @@ namespace BooruSharp.UnitTests
         [MemberData(nameof(BooruParams))]
         public async Task UnsetFavoriteErrorAsync(Type t)
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             var id = (await General.GetRandomPostAsync(booru)).ID;
 
             var prevAuth = booru.Auth;
@@ -159,7 +159,7 @@ namespace BooruSharp.UnitTests
         [MemberData(nameof(BooruParams))]
         public async Task SetFavoriteInvalidIdAsync(Type t)
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
 
             Skip.If(booru is Xbooru, "Xbooru allows adding a post with invalid ID.");
 
@@ -178,7 +178,7 @@ namespace BooruSharp.UnitTests
         public async Task SetFavoriteAsync(Type t)
         {
             const int postID = 10;
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
 
             if (!booru.HasFavoriteAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(() => booru.AddFavoriteAsync(postID));
@@ -197,7 +197,7 @@ namespace BooruSharp.UnitTests
         [MemberData(nameof(BooruParams))]
         public async Task GetByMd5Async(Type t)
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             if (!booru.HasPostByMd5API)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(() => booru.GetPostByMd5Async("0"));
             else
@@ -216,7 +216,7 @@ namespace BooruSharp.UnitTests
         [MemberData(nameof(BooruParams))]
         public async Task GetByIdAsync(Type t)
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             if (!booru.HasPostByIdAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(() => booru.GetPostByIdAsync(0));
             else
@@ -231,7 +231,7 @@ namespace BooruSharp.UnitTests
         [MemberData(nameof(BooruParams))]
         public async Task GetLastPostsAsync(Type t)
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             if (booru.NoEmptyPostSearch)
                 await Assert.ThrowsAsync<ArgumentException>(() => booru.GetLastPostsAsync());
             else
@@ -246,7 +246,7 @@ namespace BooruSharp.UnitTests
         [MemberData(nameof(BooruPostCountParams))]
         public async Task GetLastPostsWithTagsAsync(Type t, string tag = "hibiki_(kantai_collection)", string tag2 = "swimsuit")
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             Search.Post.SearchResult[] results;
             results = await booru.GetLastPostsAsync(tag, tag2);
             Assert.NotInRange(results.Length, 0, 1);
@@ -262,7 +262,7 @@ namespace BooruSharp.UnitTests
         [MemberData(nameof(BooruPostCountParams))]
         public async Task GetPostCountAsync(Type t, string tag = "hibiki_(kantai_collection)", string tag2 = "swimsuit")
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             if (!booru.HasPostCountAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(() => booru.GetPostCountAsync());
             else
@@ -284,14 +284,14 @@ namespace BooruSharp.UnitTests
         [MemberData(nameof(BooruRandomPostsParams))]
         public async Task GetRandomAsync(Type t, string tag = "school_swimsuit")
         {
-            await General.CheckGetRandomAsync(await Boorus.GetAsync(t), tag);
+            await General.CheckGetRandomAsync(Boorus.Get(t), tag);
         }
 
         [SkippableTheory]
         [MemberData(nameof(BooruRandomPostsParams))]
         public async Task GetRandomsAsync(Type t, string tag = "school_swimsuit")
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             if (!booru.HasMultipleRandomAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(() => General.CheckGetRandomsAsync(booru, tag));
             else
@@ -302,7 +302,7 @@ namespace BooruSharp.UnitTests
         [MemberData(nameof(BooruRandomPostsParams))]
         public async Task GetRandomsTooManyAsync(Type t, string tag = "school_swimsuit")
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             if (!booru.HasMultipleRandomAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(() => booru.GetRandomPostsAsync(int.MaxValue, tag));
             else
@@ -330,7 +330,7 @@ namespace BooruSharp.UnitTests
         [MemberData(nameof(BooruRandomTwoTagsParams))]
         public async Task GetRandom2TagsAsync(Type t, string tag = "hibiki_(kantai_collection)", string tag2 = "school_swimsuit")
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             var result = await booru.GetRandomPostAsync(tag, tag2);
             Assert.Contains(result.Tags, t => t.Contains(tag));
             Assert.Contains(result.Tags, t => t.Contains(tag2));
@@ -340,7 +340,7 @@ namespace BooruSharp.UnitTests
         [MemberData(nameof(BooruRandomTwoTagsParams))]
         public async Task GetRandoms2TagsAsync(Type t, string tag = "hibiki_(kantai_collection)", string tag2 = "school_swimsuit")
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             if (!booru.HasMultipleRandomAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(() => booru.GetRandomPostsAsync(_randomPostCount, tag, tag2));
             else
@@ -360,7 +360,7 @@ namespace BooruSharp.UnitTests
         public async Task TooManyTagsAsync(
             Type t, bool throwError, string tag = "ocean", string tag2 = "flat_chest", string tag3 = "swimsuit")
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             Search.Post.SearchResult result;
             if (throwError)
             {
@@ -383,7 +383,7 @@ namespace BooruSharp.UnitTests
         public async Task TooManyTagsManyAsync(
             Type t, bool throwError, string tag = "ocean", string tag2 = "flat_chest", string tag3 = "swimsuit")
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             Search.Post.SearchResult[] result;
             if (throwError)
             {
@@ -412,14 +412,14 @@ namespace BooruSharp.UnitTests
         public async Task GetRandomFailAsync(Type t)
         {
             await Assert.ThrowsAsync<Search.InvalidTags>(
-                async () => await (await Boorus.GetAsync(t)).GetRandomPostAsync("someInvalidTag"));
+                async () => await Boorus.Get(t).GetRandomPostAsync("someInvalidTag"));
         }
 
         [SkippableTheory]
         [MemberData(nameof(BooruParams))]
         public async Task GetRandomsFailAsync(Type t)
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             if (!booru.HasMultipleRandomAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(
                     () => booru.GetRandomPostsAsync(_randomPostCount, "someInvalidTag"));
@@ -446,7 +446,7 @@ namespace BooruSharp.UnitTests
         [InlineData(typeof(Pixiv), "パンスト")]
         public async Task CheckTagAsync(Type t, string tag = "pantyhose")
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             if (!booru.HasTagByIdAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(() => booru.GetTagAsync(tag));
             else
@@ -457,7 +457,7 @@ namespace BooruSharp.UnitTests
         [MemberData(nameof(BooruParams))]
         public async Task CheckTagFailAsync(Type t)
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             if (!booru.HasTagByIdAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(() => booru.GetTagAsync("someRandomTag"));
             else
@@ -483,7 +483,7 @@ namespace BooruSharp.UnitTests
         [InlineData(typeof(Pixiv), "艦隊こ", false)]
         public async Task CheckTagsAsync(Type t, string tag, bool onlyOnce)
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             if (!booru.HasTagByIdAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(() => booru.GetTagAsync(tag));
             else if (onlyOnce)
@@ -511,7 +511,7 @@ namespace BooruSharp.UnitTests
         [InlineData(typeof(Pixiv), "響(艦隊これくしょん)", -1)]
         public async Task TagIdAsync(Type t, string tag, int tagId)
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             if (!booru.HasTagByIdAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(() => booru.GetTagAsync(tagId));
             else
@@ -522,7 +522,7 @@ namespace BooruSharp.UnitTests
         [MemberData(nameof(BooruParams))]
         public async Task TagIdFailAsync(Type t)
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             if (!booru.HasTagByIdAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(() => booru.GetTagAsync(int.MaxValue));
             else
@@ -548,7 +548,7 @@ namespace BooruSharp.UnitTests
         [InlineData(typeof(Pixiv), "ふたなり", -1)]
         public async Task CheckWikiAsync(Type t, string tag, int? id)
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             if (!booru.HasWikiAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(() => booru.GetWikiAsync(tag));
             else
@@ -563,7 +563,7 @@ namespace BooruSharp.UnitTests
         [MemberData(nameof(BooruParams))]
         public async Task CheckWikiFailAsync(Type t)
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             if (!booru.HasWikiAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(() => booru.GetWikiAsync("yetAnotherTag"));
             else
@@ -589,7 +589,7 @@ namespace BooruSharp.UnitTests
         [InlineData(typeof(Pixiv), "空", "雲")]
         public async Task CheckRelatedAsync(Type t, string tag, string related)
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             if (!booru.HasRelatedAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(() => booru.GetRelatedAsync(tag));
             else
@@ -604,7 +604,7 @@ namespace BooruSharp.UnitTests
         [MemberData(nameof(BooruParams))]
         public async Task CheckRelatedFailAsync(Type t)
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             if (!booru.HasRelatedAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(() => booru.GetRelatedAsync("thisWillFail"));
             else
@@ -630,7 +630,7 @@ namespace BooruSharp.UnitTests
         [InlineData(typeof(Pixiv), -1)]
         public async Task CheckCommentAsync(Type t, int id)
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             if (!booru.HasCommentAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(() => booru.GetCommentsAsync(id));
             else
@@ -641,7 +641,7 @@ namespace BooruSharp.UnitTests
         [MemberData(nameof(BooruParams))]
         public async Task CheckCommentFailAsync(Type t)
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             if (!booru.HasCommentAPI)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(() => booru.GetCommentsAsync(int.MaxValue));
             else
@@ -652,7 +652,7 @@ namespace BooruSharp.UnitTests
         [MemberData(nameof(BooruParams))]
         public async Task CheckLastCommentAsync(Type t)
         {
-            var booru = await Boorus.GetAsync(t);
+            var booru = Boorus.Get(t);
             if (!booru.HasSearchLastComment)
                 await Assert.ThrowsAsync<Search.FeatureUnavailable>(() => booru.GetLastCommentsAsync());
             else
@@ -663,7 +663,7 @@ namespace BooruSharp.UnitTests
         [MemberData(nameof(BooruParams))]
         public async Task CheckAvailableAsync(Type t)
         {
-            await (await Boorus.GetAsync(t)).CheckAvailabilityAsync();
+            await Boorus.Get(t).CheckAvailabilityAsync();
         }
 
         [SkippableTheory]
@@ -685,7 +685,7 @@ namespace BooruSharp.UnitTests
         [InlineData(typeof(Pixiv), "おまんこ")]
         public async Task CheckIsSafeAsync(Type t, string explicitTag = "pussy")
         {
-            ABooru b = await Boorus.GetAsync(t);
+            ABooru b = Boorus.Get(t);
             bool isSafe = b.IsSafe;
             bool foundExplicit = false;
             for (int i = 0; i < 10; i++)

--- a/BooruSharp.UnitTests/Boorus.cs
+++ b/BooruSharp.UnitTests/Boorus.cs
@@ -7,11 +7,12 @@ using Xunit;
 
 namespace BooruSharp.UnitTests
 {
+    // TODO: make async methods into regular methods.
+    // Pixiv now uses internal Task to achieve thread safety and
+    // we don't need to wait until LoginAsync completes.
     internal static class Boorus
     {
         private static readonly Dictionary<Type, Task<ABooru>> _boorus = new Dictionary<Type, Task<ABooru>>();
-
-
 
         public static Task<ABooru> GetAsync(Type type)
         {
@@ -32,7 +33,7 @@ namespace BooruSharp.UnitTests
             return GetAsync(typeof(T));
         }
 
-        private static async Task<ABooru> CreateBooruAsync(Type type)
+        private static Task<ABooru> CreateBooruAsync(Type type)
         {
             var booru = (ABooru)Activator.CreateInstance(type);
 
@@ -43,10 +44,10 @@ namespace BooruSharp.UnitTests
 
                 Skip.If(userID == null || password == null, "Pixiv user ID and/or password aren't set.");
 
-                await pixiv.LoginAsync(userID, password);
+                pixiv.Auth = new BooruAuth(userID, password);
             }
 
-            return booru;
+            return Task.FromResult(booru);
         }
     }
 }

--- a/BooruSharp.UnitTests/Boorus.cs
+++ b/BooruSharp.UnitTests/Boorus.cs
@@ -1,26 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using BooruSharp.Booru;
 using BooruSharp.Others;
 using Xunit;
 
 namespace BooruSharp.UnitTests
 {
-    // TODO: make async methods into regular methods.
-    // Pixiv now uses internal Task to achieve thread safety and
-    // we don't need to wait until LoginAsync completes.
     internal static class Boorus
     {
-        private static readonly Dictionary<Type, Task<ABooru>> _boorus = new Dictionary<Type, Task<ABooru>>();
+        private static readonly Dictionary<Type, ABooru> _boorus = new Dictionary<Type, ABooru>();
 
-        public static Task<ABooru> GetAsync(Type type)
+        public static ABooru Get(Type type)
         {
             lock (_boorus)
             {
                 if (!_boorus.TryGetValue(type, out var booruTask))
                 {
-                    booruTask = Task.Run(() => CreateBooruAsync(type));
+                    booruTask = CreateBooru(type);
                     _boorus[type] = booruTask;
                 }
 
@@ -28,12 +24,12 @@ namespace BooruSharp.UnitTests
             }
         }
 
-        public static Task<ABooru> GetAsync<T>() where T : ABooru
+        public static ABooru Get<T>() where T : ABooru
         {
-            return GetAsync(typeof(T));
+            return Get(typeof(T));
         }
 
-        private static Task<ABooru> CreateBooruAsync(Type type)
+        private static ABooru CreateBooru(Type type)
         {
             var booru = (ABooru)Activator.CreateInstance(type);
 
@@ -47,7 +43,7 @@ namespace BooruSharp.UnitTests
                 pixiv.Auth = new BooruAuth(userID, password);
             }
 
-            return Task.FromResult(booru);
+            return booru;
         }
     }
 }

--- a/BooruSharp.UnitTests/General.cs
+++ b/BooruSharp.UnitTests/General.cs
@@ -1,4 +1,5 @@
 ﻿using BooruSharp.Booru;
+using BooruSharp.Others;
 using System;
 using System.Net;
 using System.Net.Http;
@@ -133,11 +134,13 @@ namespace BooruSharp.UnitTests
             return await booru.GetRandomPostAsync();
         }
 
-        public static void Authorize(ABooru booru)
+        public static void Authorize(ABooru booru, bool usesPlainTextPassword)
         {
             string booruName = booru.GetType().Name.ToUpperInvariant();
             string userID = Environment.GetEnvironmentVariable(booruName + "_USER_ID");
-            string passwordHash = Environment.GetEnvironmentVariable(booruName + "_PASSWORD_HASH");
+            string passwordHash = usesPlainTextPassword
+                ? Environment.GetEnvironmentVariable(booruName + "_PASSWORD")
+                : Environment.GetEnvironmentVariable(booruName + "_PASSWORD_HASH");
 
             Skip.If(
                 userID == null || passwordHash == null,

--- a/BooruSharp.UnitTests/OtherTests.cs
+++ b/BooruSharp.UnitTests/OtherTests.cs
@@ -13,7 +13,7 @@ namespace BooruSharp.UnitTests
         {
             Assert.Equal(
                 Search.Tag.TagType.Character,
-                (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("cirno")).Type);
+                (await Boorus.Get<Gelbooru>().GetTagAsync("cirno")).Type);
         }
 
         [Fact]
@@ -21,7 +21,7 @@ namespace BooruSharp.UnitTests
         {
             Assert.Equal(
                 Search.Tag.TagType.Copyright,
-                (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("kantai_collection")).Type);
+                (await Boorus.Get<Gelbooru>().GetTagAsync("kantai_collection")).Type);
         }
 
         [Fact]
@@ -29,7 +29,7 @@ namespace BooruSharp.UnitTests
         {
             Assert.Equal(
                 Search.Tag.TagType.Artist,
-                (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("mtu_(orewamuzituda)")).Type);
+                (await Boorus.Get<Gelbooru>().GetTagAsync("mtu_(orewamuzituda)")).Type);
         }
 
         [Fact]
@@ -37,7 +37,7 @@ namespace BooruSharp.UnitTests
         {
             Assert.Equal(
                 Search.Tag.TagType.Metadata,
-                (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("uncensored")).Type);
+                (await Boorus.Get<Gelbooru>().GetTagAsync("uncensored")).Type);
         }
 
         [Fact]
@@ -45,7 +45,7 @@ namespace BooruSharp.UnitTests
         {
             Assert.Equal(
                 Search.Tag.TagType.Trivia,
-                (await (await Boorus.GetAsync<Gelbooru>()).GetTagAsync("futanari")).Type);
+                (await Boorus.Get<Gelbooru>().GetTagAsync("futanari")).Type);
         }
     }
 }

--- a/BooruSharp/Booru/ABooru.cs
+++ b/BooruSharp/Booru/ABooru.cs
@@ -275,7 +275,7 @@ namespace BooruSharp.Booru
         /// <summary>
         /// Gets or sets authentication credentials.
         /// </summary>
-        public BooruAuth Auth { set; get; } // Authentification
+        public virtual BooruAuth Auth { get; set; }
 
         /// <summary>
         /// Sets the <see cref="System.Net.Http.HttpClient"/> instance that will be used

--- a/BooruSharp/Booru/BooruAuth.cs
+++ b/BooruSharp/Booru/BooruAuth.cs
@@ -1,11 +1,13 @@
 ﻿using System;
+using System.Diagnostics;
 
 namespace BooruSharp.Booru
 {
     /// <summary>
     /// Represents authentication credentials.
     /// </summary>
-    public class BooruAuth
+    [DebuggerDisplay("ID: {UserId} Password: {PasswordHash}")]
+    public class BooruAuth : IEquatable<BooruAuth>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BooruAuth"/> class.
@@ -28,5 +30,26 @@ namespace BooruSharp.Booru
         /// Gets the user's password hash.
         /// </summary>
         public string PasswordHash { get; }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as BooruAuth);
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(BooruAuth other)
+        {
+            return other != null && UserId == other.UserId && PasswordHash == other.PasswordHash;
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            int hashCode = -1555372705;
+            hashCode = hashCode * -1521134295 + UserId.GetHashCode();
+            hashCode = hashCode * -1521134295 + PasswordHash.GetHashCode();
+            return hashCode;
+        }
     }
 }


### PR DESCRIPTION
This PR enables Pixiv authorization through `Auth` property.

The changes include:
- Removed `AccessToken` and `RefreshToken` properties, and `_refreshTime` field. This means access and refresh tokens are no longer publicly visible (not that they should have been visible in the first place IMO).
- `SessionInfo` struct only visible to `Pixiv` was introduced to hold all the abovementioned data in one place, and the data is now stored in the `_sessionInfoTask` field, a task that returns `SessionInfo` value.
- `ABooru`'s `Auth` property was made virtual. `Pixiv` overrides this property to inject its own logic that starts a task that retrieves session info for its methods to use.
- `LoginAsync(string, string)` method was removed completely since it is now superseded by `Auth` property.

Now all the methods that require access tokens in order to work wait for the `_sessionInfoTask` to complete internally, so setting `Auth` immediately followed by a Pixiv API call (or several calls, since they all await on the same task instance) is completely safe. In contrast previously you had to wait until `LoginAsync(string, string)` completes before you could safely perform any Pixiv API call.

Other changes not directly related to the changes above:
- Updated `Pixiv` documentation: added missing exceptions and added remaks about required authorization.
- Implemented `IEquatable` interface for `BooruAuth` class, it compares properties of two `BooruAuth` objects to determine whether they are equal. `Pixiv`'s `Auth` property makes use of this so it doesn't unnecessarily create a new authorization task even if credentials are the same.
- Refactored a bunch of repeated code into separate methods in `Pixiv`.
- Made `UnitTests.Boorus` class' methods synchronous since now there's no asynchronous method calls.