### PR TITLE
Fix URL creation

### DIFF
--- a/BooruSharp/Booru/ABooru.cs
+++ b/BooruSharp/Booru/ABooru.cs
@@ -250,10 +250,10 @@ namespace BooruSharp.Booru
         {
             var builder = new UriBuilder(url);
 
-            if (_format == UrlFormat.IndexPhp)
-                builder.Query += "&" + string.Join("&", args);
+            if (builder.Query?.Length > 1)
+                builder.Query = builder.Query.Substring(1) + "&" + string.Join("&", args);
             else
-                builder.Query = "?" + string.Join("&", args);
+                builder.Query = string.Join("&", args);
 
             return builder.Uri;
         }


### PR DESCRIPTION
Seems like on .NET Core there was some sort of safeguard to prevent incorrect usage of `Query` property that wasn't there on .NET Framework.